### PR TITLE
OZ-199: Use Single Sign-On when accessing Odoo and SENAITE

### DIFF
--- a/e2e/tests/testOdooIntegration.spec.ts
+++ b/e2e/tests/testOdooIntegration.spec.ts
@@ -18,10 +18,10 @@ test.beforeEach(async ({ page }) =>  {
 test('patient with lab order becomes customer in Odoo', async ({ page }) => {
   await page.locator("//a[contains(@class, 'full')]").click();
   await page.getByRole('menuitem', { name: 'Sales' }).click();
+  await page.getByRole('img', { name: 'Remove' }).click();
   await page.getByPlaceholder('Search...').click();
   await page.getByPlaceholder('Search...').type(`${patientName.firstName + ' ' + patientName.givenName}`);
   await page.getByPlaceholder('Search...').press('Enter');
-  await page.waitForSelector("div.table-responsive table thead tr th:nth-child(4)");
 
   // syncs patient as an Odoo customer
   const customer =

--- a/e2e/utils/functions/testBase.ts
+++ b/e2e/utils/functions/testBase.ts
@@ -24,6 +24,15 @@ export class HomePage {
     await this.page.getByRole('button', { name: 'Confirm' }).click();
   }
 
+  async goToOdoo() {
+    await this.page.goto("https://erp.ozone-qa.mekomsolutions.net/");
+    await this.page.getByRole('link', { name: 'Login with Single Sign-On' }).click();
+  }
+
+  async goToSENAITE() {
+    await this.page.goto("https://lims.ozone-qa.mekomsolutions.net/");
+  }
+
   async createPatient() {
     patientName = {
       firstName : `e2e_test_${Math.floor(Math.random() * 10000)}`,
@@ -124,17 +133,6 @@ export class HomePage {
     await this.page.getByRole('button', { name: 'Sign and close' }).click();
 
     await expect(this.page.getByText('Order placed')).toBeVisible();
-  }
-
-  async goToOdoo() {
-    await this.page.goto("https://erp.ozone-qa.mekomsolutions.net/");
-    await this.page.getByPlaceholder('Email').type('admin');
-    await this.page.getByPlaceholder('Password').type('admin');
-    await this.page.getByRole('button', { name: 'Log in' }).click();
-  }
-
-  async goToSENAITE() {
-    await this.page.goto("https://lims.ozone-qa.mekomsolutions.net/");
   }
 
   async findPatient(searchText: string) {


### PR DESCRIPTION
Ticket: [OZ-199](https://mekomsolutions.atlassian.net/browse/OZ-199)

Work done;

- Automated tests should use SSO when accessing Odoo and SENAITE

[OZ-199]: https://mekomsolutions.atlassian.net/browse/OZ-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ