### PR TITLE
OZ-236: Modify SENAITE integration test titles: 'Revising' → 'Editing' and 'Discontinuing' → 'Voiding'.

### DIFF
--- a/e2e/tests/testSenaiteIntegration.spec.ts
+++ b/e2e/tests/testSenaiteIntegration.spec.ts
@@ -50,7 +50,7 @@ test('Editing patient details with a synced lab test order edits client details 
   patientName.firstName = 'Winniefred';
 });
 
-test('Revising a synced lab order edits corresponding analysis request in SENAITE', async ({ page }) => {
+test('Editing a synced lab order edits corresponding analysis request in SENAITE', async ({ page }) => {
   // setup
   const homePage = new HomePage(page);
   await homePage.createLabOrder();
@@ -83,7 +83,7 @@ test('Revising a synced lab order edits corresponding analysis request in SENAIT
   await expect(analysisRequest).toHaveText('Sickle cell screening test Template');
 });
 
-test('Discontinuing a synced lab order cancels corresponding analysis request in SENAITE', async ({ page }) => {
+test('Voiding a synced lab order cancels corresponding analysis request in SENAITE', async ({ page }) => {
   // setup
   const homePage = new HomePage(page);
   await homePage.createLabOrder();


### PR DESCRIPTION
Ticket → [OZ-236](https://mekomsolutions.atlassian.net/browse/OZ-236?focusedCommentId=39889)

Description → Renamed test titles for editing and voiding a synced lab order to reflect the right QA scenarios being performed

[OZ-236]: https://mekomsolutions.atlassian.net/browse/OZ-236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ