### PR TITLE
OZ-360: Added delay after 'starting patient visit' to prevent random test failures.

### DIFF
--- a/e2e/utils/functions/testBase.ts
+++ b/e2e/utils/functions/testBase.ts
@@ -89,8 +89,8 @@ export class HomePage {
     await this.page.getByRole('button', { name: 'Start a visit' }).click();
     await this.page.locator('label').filter({ hasText: 'Facility Visit' }).locator('span').first().click();
     await this.page.locator('form').getByRole('button', { name: 'Start a visit' }).click();
-
     await expect(this.page.getByText('Facility Visit started successfully')).toBeVisible();
+    await delay(4000);
   }
 
   async endPatientVisit() {


### PR DESCRIPTION
Ticket →[OZ-360](https://mekomsolutions.atlassian.net/browse/OZ-360)

Description →This PR is bringing in a change that is fixing a random issue occurring with E2E tests when starting a patient visit. The tests tend to proceed to the next steps before the action for starting a patient visit is done successful.

[OZ-360]: https://mekomsolutions.atlassian.net/browse/OZ-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ