### PR TITLE
OZ-365: Publish QA test suite build status automatically to slack

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,3 +44,25 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+
+     - name: Notify slack
+       id: slack
+       uses: slackapi/slack-github-action@v1.24.0
+       with:
+        channel-id: '?'
+        payload: |
+          {
+            "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.head_commit.url || github.event.schedule.html_url  }}",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                          "type": "mrkdwn",
+                          "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.head_commit.url || github.event.schedule.html_url }}"
+                        }
+                }
+           ]
+          }
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
Ticket → [OZ-365](https://mekomsolutions.atlassian.net/browse/OZ-365)

Description → This PR brings in changes that add a job within GitHub workflow that will automatically publish the QA test suite build status to slack channel.

[OZ-365]: https://mekomsolutions.atlassian.net/browse/OZ-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ