### PR TITLE
OZ-365: Publish QA test suite build status automatically to slack

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -8,11 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Notify slack
+      - name: Notify Slack
         id: slack
         uses: slackapi/slack-github-action@v1.24.0
         with:
-         channel-id: 'GSVHTJKM2'
          payload: |
            {
              "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.schedule.html_url || github.event.head_commit.url  }}",


### PR DESCRIPTION
Ticket → [OZ-365](https://mekomsolutions.atlassian.net/browse/OZ-365)

Description → This PR brings in changes that add a job within GitHub workflow that will automatically publish the QA test suite build status to slack channel.

[OZ-365]: https://mekomsolutions.atlassian.net/browse/OZ-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ