### PR TITLE
OZ-352: Unlink inherited roles before deleting the created role.

### DIFF
--- a/e2e/tests/testKeycloakIntegration.spec.ts
+++ b/e2e/tests/testKeycloakIntegration.spec.ts
@@ -31,6 +31,8 @@ test('Creating an OpenMRS role syncs the role into Keycloak', async ({ page }) =
     await expect(page.getByText('Application: Uses Patient Summary')).toBeTruthy();
     await expect(page.getByText('Application: Has Super User Privileges')).toBeTruthy();
     await expect(page.getByText('Application: Administers System')).toBeTruthy();
+    await page.goto(`${process.env.E2E_BASE_URL}/openmrs/admin/users/role.list`);
+    await homePage.unlinkInheritedRoles();
   });
 
   test('Updating a synced OpenMRS role updates the corresponding role in Keycloak', async ({ page }) => {
@@ -63,6 +65,8 @@ test('Creating an OpenMRS role syncs the role into Keycloak', async ({ page }) =
     await page.getByTestId('attributesTab').click();
     await expect(page.getByText('Application: Registers Patients')).toBeTruthy();
     await expect(page.getByText('Application: Writes Clinical Notes')).toBeTruthy();
+    await page.goto(`${process.env.E2E_BASE_URL}/openmrs/admin/users/role.list`);
+    await homePage.unlinkUpdatedInheritedRoles();
   });
 
   test('Deleting a synced OpenMRS role deletes the corresponding role in Keycloak', async ({ page }) => {
@@ -83,13 +87,14 @@ test('Creating an OpenMRS role syncs the role into Keycloak', async ({ page }) =
     await expect(page.getByText('Application: Uses Patient Summary')).toBeTruthy();
     await expect(page.getByText('Organizational: Registration Clerk')).toBeTruthy();
     await expect(page.getByText('Application: Records Allergies')).toBeTruthy();
-    await page.goto(`${process.env.E2E_BASE_URL}/openmrs`);
+    await page.goto(`${process.env.E2E_BASE_URL}/openmrs/admin/users/role.list`);
+    await homePage.unlinkInheritedRoles();
     await homePage.deleteRole();
 
     // verify
     await page.goto(`${process.env.E2E_KEYCLOAK_URL}/admin/master/console/`);
     await homePage.goToRoles();
-    const roleName = await page.locator('table tbody tr td:nth-child(1) a');
+    const roleName = await page.locator('table tbody tr:nth-child(1) td:nth-child(1) a');
     await expect(roleName).not.toHaveText(`${randomRoleName.roleName}`);
     await page.goto(`${process.env.E2E_BASE_URL}/openmrs/admin/users/role.list`);
     await homePage.addRole();

--- a/e2e/utils/functions/testBase.ts
+++ b/e2e/utils/functions/testBase.ts
@@ -404,6 +404,30 @@ export class HomePage {
     await this.page.getByTestId('rolesTab').click();
   }
 
+  async unlinkInheritedRoles () {
+    await this.page.getByRole('link', { name: `${randomRoleName.roleName}` }).click();
+    await this.page.getByLabel('Application: Edits Existing Encounters').uncheck();
+    await this.page.getByLabel('Application: Enters Vitals').uncheck();
+    await this.page.getByLabel('Application: Records Allergies').uncheck();
+    await this.page.getByLabel('Application: Uses Patient Summary').uncheck();
+    await this.page.getByLabel('Organizational: Registration Clerk').uncheck();
+    await this.page.getByRole('button', { name: 'Save Role' }).click();
+    await expect(this.page.getByText('Role saved')).toBeVisible();
+  }
+
+  async unlinkUpdatedInheritedRoles () {
+    await this.page.getByRole('link', { name: `${randomRoleName.roleName}` }).click();
+    await this.page.getByLabel('Application: Edits Existing Encounters').uncheck();
+    await this.page.getByLabel('Application: Enters Vitals').uncheck();
+    await this.page.getByLabel('Application: Records Allergies').uncheck();
+    await this.page.getByLabel('Application: Registers Patients').uncheck();
+    await this.page.getByLabel('Application: Writes Clinical Notes').uncheck();
+    await this.page.getByLabel('Application: Uses Patient Summary').uncheck();
+    await this.page.getByLabel('Organizational: Registration Clerk').uncheck();
+    await this.page.getByRole('button', { name: 'Save Role' }).click();
+    await expect(this.page.getByText('Role saved')).toBeVisible();
+  }
+
   async deleteRole(){
     await this.page.goto(`${process.env.E2E_BASE_URL}/openmrs/admin/users/role.list`);
     await this.page.getByRole('row', { name: `${randomRoleName.roleName}` }).getByRole('checkbox').check();


### PR DESCRIPTION
Ticket  → [OZ-352](https://mekomsolutions.atlassian.net/browse/OZ-352)

Description  →This PR contain changes that detach the random created roles from their respective inherited roles before attempting to delete the role.

[OZ-352]: https://mekomsolutions.atlassian.net/browse/OZ-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ