### PR TITLE
OZ-336: Voiding an OpenMRS observation updates observations dataset in Superset

### DIFF
--- a/e2e/tests/testAnalyticsIntegration.spec.ts
+++ b/e2e/tests/testAnalyticsIntegration.spec.ts
@@ -296,8 +296,6 @@ test('Adding an OpenMRS observation syncs observation into observations table in
   // setup
   const homePage = new HomePage(page);
   await homePage.createPatient();
-  await homePage.searchOpenMRSPatientID();
-  const patientIdentifier = await page.locator('#demographics section p:nth-child(2)').textContent();
   await homePage.startPatientVisit();
   const patient_uuid = await homePage.getPatientUUID();
   await homePage.goToSuperset();
@@ -406,6 +404,50 @@ test('Adding an OpenMRS appointment syncs appointment into appointments table in
 
   await expect(appointmentStatus).toContainText('Scheduled');
   await page.getByRole('tab', { name: 'Query history' }).click();
+  await homePage.clearSQLEditor();
+});
+
+test('Voiding an OpenMRS observation updates observations dataset in Superset', async ({ page }) => {
+  // setup
+  const homePage = new HomePage(page);
+  await homePage.createPatient();
+  await homePage.startPatientVisit();
+  const patient_uuid = await homePage.getPatientUUID();
+  await homePage.addPatientBiometrics();
+
+  // replay
+  await homePage.goToSuperset();
+  await expect(page).toHaveURL(/.*superset/);
+  await homePage.selectDBSchema();
+  await homePage.clearSQLEditor();
+  let obsVoidedQuery = `SELECT obs_voided FROM Observations WHERE patient_uuid like '${patient_uuid}';`;
+
+  await page.getByRole('textbox').first().fill(obsVoidedQuery);
+  await homePage.runSQLQuery();
+
+  let firstObsVoidedState = await page.locator('div.virtual-table-cell:nth-child(1)');
+  let secondObsVoidedState = await page.locator('div.virtual-table-cell:nth-child(2)');
+  let thirdObsVoidedState = await page.locator('div.virtual-table-cell:nth-child(3)');
+  await expect(firstObsVoidedState).toContainText('false');
+  await expect(secondObsVoidedState).toContainText('false');
+  await expect(thirdObsVoidedState).toContainText('false');
+
+  await page.goto(`${E2E_BASE_URL}/openmrs/spa/home`);
+  await homePage.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await homePage.discontinueAnOpenMRSEncounter();
+
+  // verify
+  await page.goto(`${E2E_ANALYTICS_URL}/superset/sqllab`);
+  await homePage.clearSQLEditor();
+
+  await page.getByRole('textbox').first().fill(obsVoidedQuery);
+  await homePage.runSQLQuery();
+
+  await expect(firstObsVoidedState).toContainText('true');
+  await expect(secondObsVoidedState).toContainText('true');
+  await expect(thirdObsVoidedState).toContainText('true');
+
+  await page.getByRole('tab', { name: 'Results' }).click();
   await homePage.clearSQLEditor();
 });
 

--- a/e2e/tests/testAnalyticsIntegration.spec.ts
+++ b/e2e/tests/testAnalyticsIntegration.spec.ts
@@ -434,7 +434,7 @@ test('Voiding an OpenMRS observation updates observations dataset in Superset', 
 
   await page.goto(`${E2E_BASE_URL}/openmrs/spa/home`);
   await homePage.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
-  await homePage.discontinueAnOpenMRSEncounter();
+  await homePage.voidEncounter();
 
   // verify
   await page.goto(`${E2E_ANALYTICS_URL}/superset/sqllab`);

--- a/e2e/tests/testSenaiteIntegration.spec.ts
+++ b/e2e/tests/testSenaiteIntegration.spec.ts
@@ -114,7 +114,7 @@ test('Voiding a synced lab order cancels corresponding analysis request in SENAI
   // replay
   await page.goto(`${E2E_BASE_URL}`);
   await homePage.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
-  await homePage.discontinueLabOrder();
+  await homePage.discontinueAnOpenMRSEncounter();
 
   // verify
   await homePage.goToSENAITE();

--- a/e2e/tests/testSenaiteIntegration.spec.ts
+++ b/e2e/tests/testSenaiteIntegration.spec.ts
@@ -114,7 +114,7 @@ test('Voiding a synced lab order cancels corresponding analysis request in SENAI
   // replay
   await page.goto(`${E2E_BASE_URL}`);
   await homePage.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
-  await homePage.discontinueAnOpenMRSEncounter();
+  await homePage.voidEncounter();
 
   // verify
   await homePage.goToSENAITE();

--- a/e2e/utils/functions/testBase.ts
+++ b/e2e/utils/functions/testBase.ts
@@ -308,7 +308,7 @@ export class HomePage {
     await delay(5000);
   }
 
-  async discontinueLabOrder() {
+  async discontinueAnOpenMRSEncounter() {
     await this.page.getByRole('link', { name: 'Visits' }).click();
     await this.page.getByRole('tab', { name: 'All encounters' }).click();
     await this.page.getByRole('button', { name: 'Options', exact: true }).click();

--- a/e2e/utils/functions/testBase.ts
+++ b/e2e/utils/functions/testBase.ts
@@ -308,7 +308,7 @@ export class HomePage {
     await delay(5000);
   }
 
-  async discontinueAnOpenMRSEncounter() {
+  async voidEncounter() {
     await this.page.getByRole('link', { name: 'Visits' }).click();
     await this.page.getByRole('tab', { name: 'All encounters' }).click();
     await this.page.getByRole('button', { name: 'Options', exact: true }).click();


### PR DESCRIPTION
Ticket → [OZ-336](https://mekomsolutions.atlassian.net/browse/OZ-336?focusedCommentId=41838)

[OZ-336]: https://mekomsolutions.atlassian.net/browse/OZ-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Description → This PR adds E2E test asserting that voiding an OpenMRS observation updates observations dataset in Superset