### PR TITLE
Upgraded playwright to 1.42.1 + Renamed 'User' to 'My Account'

### DIFF
--- a/e2e/utils/functions/testBase.ts
+++ b/e2e/utils/functions/testBase.ts
@@ -597,7 +597,7 @@ export class HomePage {
     await expect(this.page.getByRole('button', { name: 'Search Patient' })).toBeEnabled();
     await expect(this.page.getByRole('button', { name: 'Add Patient' })).toBeEnabled();
     await expect(this.page.getByRole('button', { name: 'Implementer Tools' })).toBeEnabled();
-    await expect(this.page.getByRole('button', { name: 'User' })).toBeEnabled();
+    await expect(this.page.getByRole('button', { name: 'My Account' })).toBeEnabled();
     await expect(this.page.getByRole('button', { name: 'App Menu' })).toBeEnabled();
   }
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.40.0",
+    "@playwright/test": "^1.42.1",
     "@types/node": "^20.8.10",
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.2.7",


### PR DESCRIPTION
This upgrades playwright to the latest version 1.42.1 (See release notes at https://playwright.dev/docs/release-notes) + Renaming 'User' to 'My account' as a change from upstream. 
