### PR TITLE
 Remove 'publish' script from package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,6 @@ jobs:
 
       - name: Publish to NPM repository
         shell: pwsh
-        run: npm run publish
+        run: yarn config set npmAuthToken "${{ secrets.NPM_AUTH_TOKEN }}" && yarn run publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   release:
     types:
       - created

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '18'
           registry-url: 'https://nexus.mekomsolutions.net/repository/npm-public/'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,16 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: 20
           registry-url: 'https://nexus.mekomsolutions.net/repository/npm-public/'
 
       - name: Install dependencies
         run: yarn install
 
       - name: Publish to NPM repository
-        shell: pwsh
-        run: yarn config set npmAuthToken "${{ secrets.NPM_AUTH_TOKEN }}" && yarn run publish
+        run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20.x'
           registry-url: 'https://nexus.mekomsolutions.net/repository/npm-public/'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   release:
     types:
       - created
@@ -22,6 +25,7 @@ jobs:
         run: yarn install
 
       - name: Publish to NPM repository
+        shell: pwsh
         run: npm run publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   ],
   "scripts": {
     "proE2ETests": "npx playwright test",
-    "fossE2ETests": "npx playwright test Odoo Senaite",
-    "publish": "npm publish"
+    "fossE2ETests": "npx playwright test Odoo Senaite"
   },
   "publishConfig": {
     "registry": "https://nexus.mekomsolutions.net/repository/npm-public/"


### PR DESCRIPTION
This PR addresses the failures occurring in GitHub Actions when publishing E2E tests to the NPM Registry. 