### PR TITLE
OZ-523: Use 'next' version to track the Ozone bleeding edge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,6 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Set package version
-        run: |
-          git config user.email "'" && git config user.name "ozone-his"
-          yarn version --new-version "$(node -e "console.log(require('semver').inc(require('./package.json').version, 'patch'))")-pre.${{ github.run_number }}"
-
       - name: Publish to NPM repository
         run: yarn publish
         env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ozone-e2e",
-  "version": "1.0.0-alpha",
+  "version": "next",
   "license": "MPL-2.0",
   "description": "These are end-to-end automated tests covering all Ozone HIS workflows",
   "main": "index.js",
@@ -27,7 +27,6 @@
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.2.7",
     "dotenv": "^16.3.1",
-    "typescript": "^4.5.5",
-    "semver": "^7.5.4"
+    "typescript": "^4.5.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,13 +66,6 @@ fsevents@2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
-  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
-  dependencies:
-    yallist "^4.0.0"
-
 playwright-core@1.43.0:
   version "1.43.0"
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.43.0.tgz#d8079acb653abebb0b63062e432479647a4e1271"
@@ -87,13 +80,6 @@ playwright@1.43.0:
   optionalDependencies:
     fsevents "2.3.2"
 
-semver@^7.5.4:
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
-  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
-  dependencies:
-    lru-cache "^6.0.0"
-
 typescript@^4.5.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
@@ -103,8 +89,3 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==


### PR DESCRIPTION
Ticket [OZ-523](https://mekomsolutions.atlassian.net/browse/OZ-523)

This PR adjusts Ozone E2E versioning in order  track the Ozone bleeding edge. As soon as when there is a release of Ozone, we release Ozone E2E version with the corresponding Ozone version.

Reference: https://mekomsolutions.slack.com/archives/G421UNF5L/p1712914368677929?thread_ts=1712911941.447549&cid=G421UNF5L

[OZ-523]: https://mekomsolutions.atlassian.net/browse/OZ-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ