### PR TITLE
OZ-554: E2E tests for handling voided entities when streaming with Analytics

### DIFF
--- a/e2e/tests/odoo-openmrs-flows.spec.ts
+++ b/e2e/tests/odoo-openmrs-flows.spec.ts
@@ -199,6 +199,6 @@ test('Ordering a drug with a free text medication dosage for an OpenMRS patient 
 });
 
 test.afterEach(async ({ page }) => {
-  await openmrs.deletePatient();
+  await openmrs.voidPatient();
   await page.close();
 });

--- a/e2e/tests/openmrs-senaite-flows.spec.ts
+++ b/e2e/tests/openmrs-senaite-flows.spec.ts
@@ -183,6 +183,6 @@ test('Published free text lab results from SENAITE are viewable in the OpenMRS l
 });
 
 test.afterEach(async ({ page }) => {
-  await openmrs.deletePatient();
+  await openmrs.voidPatient
   await page.close();
 });

--- a/e2e/tests/openmrs-superset-flows.spec.ts
+++ b/e2e/tests/openmrs-superset-flows.spec.ts
@@ -473,7 +473,7 @@ test('Voiding an OpenMRS patient updates the patient in Superset patients table.
   await superset.clearSQLEditor();
 });
 
-test('Voiding an OpenMRS condition update the condition in Superset conditions table.', async ({ page }) => {
+test('Voiding an OpenMRS condition updates the condition in Superset conditions table.', async ({ page }) => {
   // setup
   await openmrs.createPatient();
   await openmrs.searchPatientId();

--- a/e2e/tests/openmrs-superset-flows.spec.ts
+++ b/e2e/tests/openmrs-superset-flows.spec.ts
@@ -58,7 +58,7 @@ test('Creating an OpenMRS patient creates the patient in Superset patients table
   await expect(patientGender).toHaveText('M');
   await page.getByRole('tab', { name: 'Results' }).click();
   await superset.clearSQLEditor();
-  await openmrs.deletePatient();
+  await openmrs.voidPatient();
 });
 
 test('Creating an OpenMRS visit creates the visit in Superset visits table.', async ({ page }) => {
@@ -105,7 +105,7 @@ test('Creating an OpenMRS visit creates the visit in Superset visits table.', as
   await expect(patientAgeAtVisit).toBe(24);
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
-  await openmrs.deletePatient();
+  await openmrs.voidPatient();
 });
 
 test('Creating an OpenMRS order creates the order in Superset orders table.', async ({ page }) => {
@@ -163,7 +163,7 @@ test('Creating an OpenMRS order creates the order in Superset orders table.', as
   await expect(encounterTypeName).toContainText('Consultation');
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
-  await openmrs.deletePatient();
+  await openmrs.voidPatient();
 });
 
 test('Creating an OpenMRS encounter creates the encounter in Superset encounters table.', async ({ page }) => {
@@ -234,7 +234,7 @@ test('Creating an OpenMRS encounter creates the encounter in Superset encounters
   await expect(visitTypeName).toContainText('Facility Visit');
   await page.getByRole('tab', { name: 'Results' }).click();
   await superset.clearSQLEditor();
-  await openmrs.deletePatient();
+  await openmrs.voidPatient();
 });
 
 test('Creating an OpenMRS condition creates the condition in Superset conditions table.', async ({ page }) => {
@@ -289,7 +289,7 @@ test('Creating an OpenMRS condition creates the condition in Superset conditions
   await expect(onSetDate).toContainText('2023-07-27T00:00:00');
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
-  await openmrs.deletePatient();
+  await openmrs.voidPatient();
 });
 
 test('Creating an OpenMRS obs creates the observation in Superset observations table.', async ({ page }) => {
@@ -347,7 +347,7 @@ test('Creating an OpenMRS obs creates the observation in Superset observations t
   await expect(patientMidUpperArmCircumference).toBe(34);
   await page.getByRole('tab', { name: 'Results' }).click();
   await superset.clearSQLEditor();
-  await openmrs.deletePatient();
+  await openmrs.voidPatient();
 });
 
 test('Creating an OpenMRS appointment creates the appointment in Superset appointments table.', async ({ page }) => {
@@ -400,7 +400,7 @@ test('Creating an OpenMRS appointment creates the appointment in Superset appoin
   await expect(appointmentStatus).toContainText('Scheduled');
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
-  await openmrs.deletePatient();
+  await openmrs.voidPatient();
 });
 
 test('Voiding an OpenMRS obs updates the observation in Superset observations table.', async ({ page }) => {
@@ -441,7 +441,7 @@ test('Voiding an OpenMRS obs updates the observation in Superset observations ta
 
   await page.getByRole('tab', { name: 'Results' }).click();
   await superset.clearSQLEditor();
-  await openmrs.deletePatient();
+  await openmrs.voidPatient();
 });
 
 test('Voiding an OpenMRS patient updates the patient in Superset patients table.', async ({ page }) => {
@@ -461,7 +461,7 @@ test('Voiding an OpenMRS patient updates the patient in Superset patients table.
   await expect(patientVoidedState).toContainText('false');
 
   // replay
-  await openmrs.deletePatient();
+  await openmrs.voidPatient();
 
   // verify
   await page.goto(`${SUPERSET_URL}/superset/sqllab`);
@@ -511,7 +511,7 @@ test('Voiding an OpenMRS condition updates the condition in Superset conditions 
 
   await expect(conditionVoidedState).toContainText('true');
   await superset.clearSQLEditor();
-  await openmrs.deletePatient();
+  await openmrs.voidPatient();
 });
 
 test('Voiding an OpenMRS encounter updates the encounter in Superset encounters table.', async ({ page }) => {
@@ -569,7 +569,7 @@ test('Voiding an OpenMRS encounter updates the encounter in Superset encounters 
 
   await expect(encounterVoidedState).toContainText('true');
   await superset.clearSQLEditor();
-  await openmrs.deletePatient();
+  await openmrs.voidPatient();
 });
 
 test('Cancelling an OpenMRS appointment updates the appointment in Superset appointments table.', async ({ page }) => {
@@ -611,7 +611,7 @@ test('Cancelling an OpenMRS appointment updates the appointment in Superset appo
 
   await expect(appointmentStatus).toContainText('Cancelled');
   await superset.clearSQLEditor();
-  await openmrs.deletePatient();
+  await openmrs.voidPatient();
 });
 
 test.afterEach(async ({ page }) => {

--- a/e2e/tests/openmrs-superset-flows.spec.ts
+++ b/e2e/tests/openmrs-superset-flows.spec.ts
@@ -15,7 +15,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('Creating an OpenMRS patient creates the patient in Superset patients table.', async ({ page }) => {
-  // replay
+  // setup
   await superset.open();
   await expect(page).toHaveURL(/.*superset/);
   await superset.selectDBSchema();
@@ -27,6 +27,8 @@ test('Creating an OpenMRS patient creates the patient in Superset patients table
   let initialPatientsCount = Number(initialNumberOfPatients);
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
+
+  // replay
   await page.goto(`${O3_URL}`);
   await openmrs.createPatient();
   await openmrs.searchPatientId();
@@ -56,10 +58,11 @@ test('Creating an OpenMRS patient creates the patient in Superset patients table
   await expect(patientGender).toHaveText('M');
   await page.getByRole('tab', { name: 'Results' }).click();
   await superset.clearSQLEditor();
+  await openmrs.deletePatient();
 });
 
 test('Creating an OpenMRS visit creates the visit in Superset visits table.', async ({ page }) => {
-  // replay
+  // setup
   await openmrs.createPatient();
   await superset.open();
   await expect(page).toHaveURL(/.*superset/);
@@ -72,6 +75,8 @@ test('Creating an OpenMRS visit creates the visit in Superset visits table.', as
   let initialVisitsCount = Number(initialNumberOfVisits);
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
+
+  // replay
   await page.goto(`${O3_URL}`);
   await openmrs.startPatientVisit();
   const patient_uuid = await openmrs.getPatientUuid();
@@ -100,10 +105,11 @@ test('Creating an OpenMRS visit creates the visit in Superset visits table.', as
   await expect(patientAgeAtVisit).toBe(24);
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
+  await openmrs.deletePatient();
 });
 
 test('Creating an OpenMRS order creates the order in Superset orders table.', async ({ page }) => {
-  // replay
+  // setup
   await openmrs.createPatient();
   await openmrs.searchPatientId();
   const patientIdentifier = await page.locator('#demographics section p:nth-child(2)').textContent();
@@ -119,6 +125,8 @@ test('Creating an OpenMRS order creates the order in Superset orders table.', as
   let initialOrdersCount = Number(initialNumberOfOrders);
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
+
+  // replay
   await page.goto(`${O3_URL}`);
   await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
   await openmrs.goToLabOrderForm();
@@ -155,10 +163,11 @@ test('Creating an OpenMRS order creates the order in Superset orders table.', as
   await expect(encounterTypeName).toContainText('Consultation');
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
+  await openmrs.deletePatient();
 });
 
 test('Creating an OpenMRS encounter creates the encounter in Superset encounters table.', async ({ page }) => {
-  // replay
+  // setup
   await openmrs.createPatient();
   await openmrs.searchPatientId();
   const patientIdentifier = await page.locator('#demographics section p:nth-child(2)').textContent();
@@ -174,6 +183,8 @@ test('Creating an OpenMRS encounter creates the encounter in Superset encounters
   let initialEncountersCount = Number(initialNumberOfEncounters);
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
+
+  // replay
   await page.goto(`${O3_URL}`);
   await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
   await openmrs.goToLabOrderForm();
@@ -223,10 +234,11 @@ test('Creating an OpenMRS encounter creates the encounter in Superset encounters
   await expect(visitTypeName).toContainText('Facility Visit');
   await page.getByRole('tab', { name: 'Results' }).click();
   await superset.clearSQLEditor();
+  await openmrs.deletePatient();
 });
 
 test('Creating an OpenMRS condition creates the condition in Superset conditions table.', async ({ page }) => {
-  // replay
+  // setup
   await openmrs.createPatient();
   await openmrs.searchPatientId();
   const patientIdentifier = await page.locator('#demographics section p:nth-child(2)').textContent();
@@ -242,6 +254,8 @@ test('Creating an OpenMRS condition creates the condition in Superset conditions
   let initialConditionsCount = Number(initialNumberOfConditions);
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
+
+  // replay
   await page.goto(`${O3_URL}`);
   await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
   await openmrs.addPatientCondition();
@@ -275,10 +289,11 @@ test('Creating an OpenMRS condition creates the condition in Superset conditions
   await expect(onSetDate).toContainText('2023-07-27T00:00:00');
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
+  await openmrs.deletePatient();
 });
 
 test('Creating an OpenMRS obs creates the observation in Superset observations table.', async ({ page }) => {
-  // replay
+  // setup
   await openmrs.createPatient();
   await openmrs.startPatientVisit();
   const patient_uuid = await openmrs.getPatientUuid();
@@ -293,6 +308,8 @@ test('Creating an OpenMRS obs creates the observation in Superset observations t
   let initialObservationsCount = Number(initialNumberOfObservations);
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
+
+  // replay
   await page.goto(`${O3_URL}`);
   await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
   await openmrs.addPatientBiometrics();
@@ -330,10 +347,11 @@ test('Creating an OpenMRS obs creates the observation in Superset observations t
   await expect(patientMidUpperArmCircumference).toBe(34);
   await page.getByRole('tab', { name: 'Results' }).click();
   await superset.clearSQLEditor();
+  await openmrs.deletePatient();
 });
 
 test('Creating an OpenMRS appointment creates the appointment in Superset appointments table.', async ({ page }) => {
-  // replay
+  // setup
   await openmrs.createPatient();
   await openmrs.searchPatientId();
   const patientIdentifier = await page.locator('#demographics section p:nth-child(2)').textContent();
@@ -349,6 +367,8 @@ test('Creating an OpenMRS appointment creates the appointment in Superset appoin
   let initialAppointmentsCount = Number(initialNumberOfAppointments);
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
+
+  // replay
   await page.goto(`${O3_URL}`);
   await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
   await openmrs.addPatientAppointment();
@@ -380,10 +400,11 @@ test('Creating an OpenMRS appointment creates the appointment in Superset appoin
   await expect(appointmentStatus).toContainText('Scheduled');
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
+  await openmrs.deletePatient();
 });
 
 test('Voiding an OpenMRS obs updates the observation in Superset observations table.', async ({ page }) => {
-  // replay
+  // setup
   await openmrs.createPatient();
   await openmrs.startPatientVisit();
   const patient_uuid = await openmrs.getPatientUuid();
@@ -403,6 +424,7 @@ test('Voiding an OpenMRS obs updates the observation in Superset observations ta
   await expect(secondObsVoidedState).toContainText('false');
   await expect(thirdObsVoidedState).toContainText('false');
 
+  // replay
   await page.goto(`${O3_URL}/openmrs/spa/home`);
   await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
   await openmrs.voidEncounter();
@@ -419,9 +441,179 @@ test('Voiding an OpenMRS obs updates the observation in Superset observations ta
 
   await page.getByRole('tab', { name: 'Results' }).click();
   await superset.clearSQLEditor();
+  await openmrs.deletePatient();
+});
+
+test('Voiding an OpenMRS patient updates the patient in Superset patients table.', async ({ page }) => {
+  // setup
+  await openmrs.createPatient();
+  await openmrs.searchPatientId();
+  const patientIdentifier = await page.locator('#demographics section p:nth-child(2)').textContent();
+  await superset.open();
+  await expect(page).toHaveURL(/.*superset/);
+  await superset.selectDBSchema();
+  await superset.clearSQLEditor();
+  let personVoidedQuery = `SELECT person_voided FROM patients where identifiers like 'OpenMRS ID: ${patientIdentifier}';`;
+  await page.getByRole('textbox').first().fill(personVoidedQuery);
+  await superset.runSQLQuery();
+  let patientVoidedState = await page.locator('div.virtual-table-cell');
+
+  await expect(patientVoidedState).toContainText('false');
+
+  // replay
+  await openmrs.deletePatient();
+
+  // verify
+  await page.goto(`${SUPERSET_URL}/superset/sqllab`);
+  await superset.clearSQLEditor();
+  await page.getByRole('textbox').first().fill(personVoidedQuery);
+  await superset.runSQLQuery();
+
+  await expect(patientVoidedState).toContainText('true');
+  await superset.clearSQLEditor();
+});
+
+test('Voiding an OpenMRS condition update the condition in Superset conditions table.', async ({ page }) => {
+  // setup
+  await openmrs.createPatient();
+  await openmrs.searchPatientId();
+  const patientIdentifier = await page.locator('#demographics section p:nth-child(2)').textContent();
+  await openmrs.startPatientVisit();
+  await openmrs.addPatientCondition();
+  await superset.open();
+  await expect(page).toHaveURL(/.*superset/);
+  await superset.selectDBSchema();
+  await superset.clearSQLEditor();
+  let patientIdQuery = `SELECT patient_id FROM patients WHERE identifiers like 'OpenMRS ID: ${patientIdentifier}';`;
+  await page.getByRole('textbox').first().fill(patientIdQuery);
+  await superset.runSQLQuery();
+  let patientId = await page.locator('div.virtual-table-cell').textContent();
+  const patientIdValue = Number(patientId);
+  await superset.clearSQLEditor();
+  let conditionVoidedQuery = `SELECT voided FROM conditions WHERE patient_id=${patientIdValue};`;
+  await page.getByRole('textbox').first().fill(conditionVoidedQuery);
+  await superset.runSQLQuery();
+  let conditionVoidedState = await page.locator('div.virtual-table-cell');
+
+  await expect(conditionVoidedState).toContainText('false');
+  await superset.clearSQLEditor();
+
+  // replay
+  await page.goto(`${O3_URL}`);
+  await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await openmrs.voidPatientCondition();
+
+  // verify
+  await page.goto(`${SUPERSET_URL}/superset/sqllab`);
+  await superset.clearSQLEditor();
+  await page.getByRole('textbox').first().fill(conditionVoidedQuery);
+  await superset.runSQLQuery();
+
+  await expect(conditionVoidedState).toContainText('true');
+  await superset.clearSQLEditor();
+  await openmrs.deletePatient();
+});
+
+test('Voiding an OpenMRS encounter updates the encounter in Superset encounters table.', async ({ page }) => {
+  // setup
+  await openmrs.createPatient();
+  await openmrs.searchPatientId();
+  const patientIdentifier = await page.locator('#demographics section p:nth-child(2)').textContent();
+  await openmrs.startPatientVisit();
+  await openmrs.goToLabOrderForm();
+  await page.getByRole('button', { name: 'Add', exact: true }).click();
+  await page.locator('#tab select').selectOption('857AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+  await openmrs.saveLabOrder();
+  await superset.open();
+  await expect(page).toHaveURL(/.*superset/);
+  await superset.selectDBSchema();
+  await superset.clearSQLEditor();
+  let patientIdQuery = `SELECT patient_id FROM patients WHERE identifiers like 'OpenMRS ID: ${patientIdentifier}';`;
+  await page.getByRole('textbox').first().fill(patientIdQuery);
+  await superset.runSQLQuery();
+  let patientId = await page.locator('div.virtual-table-cell').textContent();
+  const patientIdValue = Number(patientId);
+  await page.getByRole('tab', { name: 'Results' }).click();
+  await superset.clearSQLEditor();
+  let encounterIdQuery = `SELECT encounter_id FROM orders WHERE patient_id=${patientIdValue};`;
+  await page.getByRole('textbox').first().fill(encounterIdQuery);
+  await superset.runSQLQuery();
+  let encounterId = await page.locator('div.virtual-table-cell').textContent();
+  const encounterIdValue = Number(encounterId);
+  await page.getByRole('tab', { name: 'Query history' }).click();
+  await superset.clearSQLEditor();
+  let encounterTypeUuidQuery = `SELECT encounter_type_uuid FROM orders WHERE patient_id=${patientIdValue};`;
+  await page.getByRole('textbox').fill(encounterTypeUuidQuery);
+  await superset.runSQLQuery();
+  let encounterTypeUuidValue = await page.locator('div.virtual-table-cell').textContent();
+  await page.getByRole('tab', { name: 'Results' }).click();
+  await superset.clearSQLEditor();
+  let encounterVoidedQuery = `SELECT encounter_voided FROM encounters WHERE encounter_id=${encounterIdValue} AND encounter_type_uuid like '${encounterTypeUuidValue}';`;
+  await page.getByRole('textbox').first().fill(encounterVoidedQuery);
+  await superset.runSQLQuery();
+  let encounterVoidedState = await page.locator('div.virtual-table-cell');
+
+  await expect(encounterVoidedState).toContainText('false');
+  await superset.clearSQLEditor();
+
+  // replay
+  await page.goto(`${O3_URL}`);
+  await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await openmrs.voidEncounter();
+
+  // verify
+  await page.goto(`${SUPERSET_URL}/superset/sqllab`);
+  await superset.clearSQLEditor();
+  await page.getByRole('textbox').first().fill(encounterVoidedQuery);
+  await superset.runSQLQuery();
+
+  await expect(encounterVoidedState).toContainText('true');
+  await superset.clearSQLEditor();
+  await openmrs.deletePatient();
+});
+
+test('Cancelling an OpenMRS appointment updates the appointment in Superset appointments table.', async ({ page }) => {
+  // setup
+  await openmrs.createPatient();
+  await openmrs.searchPatientId();
+  const patientIdentifier = await page.locator('#demographics section p:nth-child(2)').textContent();
+  await openmrs.startPatientVisit();
+  await openmrs.addPatientAppointment();
+  await superset.open();
+  await expect(page).toHaveURL(/.*superset/);
+  await superset.selectDBSchema();
+  await superset.clearSQLEditor();
+  let patientIdQuery = `SELECT patient_id FROM patients WHERE identifiers like 'OpenMRS ID: ${patientIdentifier}';`;
+  await page.getByRole('textbox').first().fill(patientIdQuery);
+  await superset.runSQLQuery();
+  let patientId = await page.locator('div.virtual-table-cell').textContent();
+  const patientIdValue = Number(patientId);
+  await page.getByRole('tab', { name: 'Results' }).click();
+  await superset.clearSQLEditor();
+  let appointmentStatusQuery = `SELECT status FROM appointments WHERE patient_id=${patientIdValue};`;
+  await page.getByRole('textbox').first().fill(appointmentStatusQuery);
+  await superset.runSQLQuery();
+  let appointmentStatus = await page.locator('div.virtual-table-cell');
+
+  await expect(appointmentStatus).toContainText('Scheduled');
+  await superset.clearSQLEditor();
+
+  // replay
+  await page.goto(`${O3_URL}`);
+  await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await openmrs.cancelPatientAppointment();
+
+  // verify
+  await page.goto(`${SUPERSET_URL}/superset/sqllab`);
+  await superset.clearSQLEditor();
+  await page.getByRole('textbox').first().fill(appointmentStatusQuery);
+  await superset.runSQLQuery();
+
+  await expect(appointmentStatus).toContainText('Cancelled');
+  await superset.clearSQLEditor();
+  await openmrs.deletePatient();
 });
 
 test.afterEach(async ({ page }) => {
-  await openmrs.deletePatient();
   await page.close();
 });

--- a/e2e/utils/functions/openmrs.ts
+++ b/e2e/utils/functions/openmrs.ts
@@ -149,7 +149,7 @@ export class OpenMRS {
     await this.page.goto(`${O3_URL}/openmrs/admin/patients/index.htm`);
     await this.page.getByPlaceholder(' ').type(`${patientName.firstName + ' ' + patientName.givenName}`);
     await this.page.locator('#openmrsSearchTable tbody tr.odd td:nth-child(1)').click();
-    await this.page.locator('input[name="voidReason"]').fill('Delete patient created by smoke tests');
+    await this.page.locator('input[name="voidReason"]').fill('Void patient created by smoke test');
     await this.page.getByRole('button', { name: 'Delete Patient', exact: true }).click();
     const message = await this.page.locator('//*[@id="patientFormVoided"]').textContent();
     await expect(message?.includes('This patient has been deleted')).toBeTruthy();

--- a/e2e/utils/functions/openmrs.ts
+++ b/e2e/utils/functions/openmrs.ts
@@ -153,7 +153,6 @@ export class OpenMRS {
     await this.page.getByRole('button', { name: 'Delete Patient', exact: true }).click();
     const message = await this.page.locator('//*[@id="patientFormVoided"]').textContent();
     await expect(message?.includes('This patient has been deleted')).toBeTruthy();
-    await this.page.getByRole('link', { name: 'Log out' }).click();
   }
 
   async addPatientCondition() {
@@ -168,6 +167,14 @@ export class OpenMRS {
     const patientCondition = await this.page.locator('table tbody tr:nth-child(1) td:nth-child(1)');
     await expect(patientCondition).toHaveText('Typhoid fever');
     await this.page.getByRole('button', { name: 'Close', exact: true }).click();
+  }
+
+  async voidPatientCondition() {
+    await this.page.getByRole('link', { name: 'Conditions' }).click();
+    await this.page.getByRole('button', { name: 'Options' }).click();
+    await this.page.getByRole('menuitem', { name: 'Delete' }).click();
+    await this.page.getByRole('button', { name: 'Delete' }).click();
+    await expect(this.page.getByText('Condition Deleted')).toBeVisible();
   }
 
   async addPatientBiometrics() {
@@ -199,6 +206,15 @@ export class OpenMRS {
     await expect(appointmentType).toHaveText('Scheduled');
     const appointmentStatus = await this.page.locator('table tbody tr:nth-child(1) td:nth-child(4)');
     await expect(appointmentStatus).toHaveText('Scheduled');
+  }
+
+  async cancelPatientAppointment() {
+    await this.page.getByRole('link', { name: 'Appointments' }).click();
+    await this.page.getByRole('tab', { name: 'Today' }).click();
+    await this.page.getByRole('button', { name: 'Options' }).click();
+    await this.page.getByRole('menuitem', { name: 'Cancel' }).click();
+    await this.page.getByRole('button', { name: 'Cancel appointment' }).click();
+    await expect(this.page.getByText('Appointment cancelled successfully')).toBeVisible();
   }
 
   async goToLabOrderForm() {

--- a/e2e/utils/functions/openmrs.ts
+++ b/e2e/utils/functions/openmrs.ts
@@ -145,7 +145,7 @@ export class OpenMRS {
     await this.page.getByRole('button', { name: 'Close' }).click();
   }
 
-  async deletePatient() {
+  async voidPatient() {
     await this.page.goto(`${O3_URL}/openmrs/admin/patients/index.htm`);
     await this.page.getByPlaceholder(' ').type(`${patientName.firstName + ' ' + patientName.givenName}`);
     await this.page.locator('#openmrsSearchTable tbody tr.odd td:nth-child(1)').click();

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "e2e-tests-pro": "npx playwright test",
+    "e2e-tests-pro": "npx playwright test openmrs-superset",
     "e2e-tests-foss": "npx playwright test odoo-openmrs openmrs-senaite"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "e2e-tests-pro": "npx playwright test openmrs-superset",
+    "e2e-tests-pro": "npx playwright test",
     "e2e-tests-foss": "npx playwright test odoo-openmrs openmrs-senaite"
   },
   "publishConfig": {


### PR DESCRIPTION
Ticket [OZ-554](https://mekomsolutions.atlassian.net/browse/OZ-554)

[OZ-554]: https://mekomsolutions.atlassian.net/browse/OZ-554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This PR adds the following E2E tests handling voidable entities when streaming with Analytics.

- Voiding an OpenMRS patient updates the patient in Superset patients table.
- Voiding an OpenMRS condition updates the condition in Superset conditions table.
- Voiding an OpenMRS encounter updates the encounter in Superset encounters table.
- Cancelling an OpenMRS appointment updates the appointment in Superset appointments table.