### PR TITLE
OZ-590: Refactored E2E tests for Keycloak-Superset flows + Updated playwright to 1.44.1

### DIFF
--- a/e2e/tests/keycloak-openmrs-flows.spec.ts
+++ b/e2e/tests/keycloak-openmrs-flows.spec.ts
@@ -1,25 +1,24 @@
 import { test, expect } from '@playwright/test';
 import { Keycloak, randomKeycloakRoleName } from '../utils/functions/keycloak';
 import { OpenMRS, delay, randomOpenMRSRoleName } from '../utils/functions/openmrs';
-import { Superset, randomSupersetRoleName} from '../utils/functions/superset';
 import { O3_URL, KEYCLOAK_URL } from '../utils/configs/globalSetup';
 
 let openmrs: OpenMRS;
 let keycloak: Keycloak;
-let superset: Superset;
 
 test.beforeEach(async ({ page }) => {
   openmrs = new OpenMRS(page);
   keycloak = new Keycloak(page);
-  superset = new Superset(page);
 
   await openmrs.login();
   await expect(page).toHaveURL(/.*home/);
 });
 
 test('Creating an OpenMRS role creates the corresponding Keycloak role.', async ({ page }) => {
-  // replay
+  // setup
   await page.goto(`${O3_URL}/openmrs/admin/users/role.list`);
+
+  // replay
   await openmrs.addRole();
 
   // verify
@@ -39,7 +38,7 @@ test('Creating an OpenMRS role creates the corresponding Keycloak role.', async 
 });
 
 test('Updating a synced OpenMRS role updates the corresponding Keycloak role.', async ({ page }) => {
-  // replay
+  // setup
   await page.goto(`${O3_URL}/openmrs/admin/users/role.list`);
   await openmrs.addRole();
   await keycloak.open();
@@ -54,6 +53,8 @@ test('Updating a synced OpenMRS role updates the corresponding Keycloak role.', 
   await expect(page.getByText('Application: Uses Patient Summary')).toBeTruthy();
   await expect(page.getByText('Organizational: Registration Clerk')).toBeTruthy();
   await expect(page.getByText('Application: Records Allergies')).toBeTruthy();
+
+  // replay
   await page.goto(`${O3_URL}/openmrs/admin/users/role.list`);
   await openmrs.updateRole();
 
@@ -70,7 +71,7 @@ test('Updating a synced OpenMRS role updates the corresponding Keycloak role.', 
 });
 
 test('Deleting a synced OpenMRS role deletes the corresponding Keycloak role.', async ({ page }) => {
-  // replay
+  // setup
   await page.goto(`${O3_URL}/openmrs/admin/users/role.list`);
   await openmrs.addRole();
   await keycloak.open();
@@ -85,6 +86,8 @@ test('Deleting a synced OpenMRS role deletes the corresponding Keycloak role.', 
   await expect(page.getByText('Application: Uses Patient Summary')).toBeTruthy();
   await expect(page.getByText('Organizational: Registration Clerk')).toBeTruthy();
   await expect(page.getByText('Application: Records Allergies')).toBeTruthy();
+
+  // replay
   await openmrs.deleteRole();
 
   // verify
@@ -95,81 +98,13 @@ test('Deleting a synced OpenMRS role deletes the corresponding Keycloak role.', 
   await expect(roleName).not.toHaveText(`${randomOpenMRSRoleName.roleName}`);
 });
 
-test('Creating a Superset role creates the corresponding Keycloak role.', async ({ page }) => {
-  // replay
-  await superset.open();
-  await superset.addRole();
-
-  // verify
-  await keycloak.open();
-  await keycloak.goToClients();
-  await keycloak.selectSupersetId();
-  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).toBeVisible();
-  await superset.deleteRole();
-});
-
-test('Updating a synced Superset role updates the corresponding Keycloak role.', async ({ page }) => {
-  // replay
-  await superset.open();
-  await superset.addRole();
-  await keycloak.open();
-  await keycloak.goToClients();
-  await keycloak.selectSupersetId();
-  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).toBeVisible();
-  await expect(page.getByText('')).toBeTruthy();
-  await superset.updateRole();
-
-  // verify
-  await page.goto(`${KEYCLOAK_URL}/admin/master/console`);
-  await keycloak.goToClients();
-  await keycloak.selectSupersetId();
-  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).not.toBeVisible();
-  await expect(page.getByText(`${randomSupersetRoleName.updatedRoleName}`)).toBeVisible();
-  await superset.deleteUpdatedRole();
-});
-
-test('Deleting a synced Superset role deletes the corresponding Keycloak role.', async ({ page }) => {
-  // replay
-  await superset.open();
-  await superset.addRole();
-  await keycloak.open();
-  await keycloak.goToClients();
-  await keycloak.selectSupersetId();
-  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).toBeVisible();
-  await superset.deleteRole();
-  await delay(30000);
-
-  // verify
-  await page.goto(`${KEYCLOAK_URL}/admin/master/console`);
-  await keycloak.goToClients();
-  await keycloak.selectSupersetId();
-  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).not.toBeVisible();
-});
-
-test('A synced role deleted from within Keycloak gets recreated in the subsequent polling cycle.', async ({ page }) => {
-  // replay
-  await superset.open();
-  await superset.addRole();
-
-  // verify
-  await keycloak.open();
-  await keycloak.goToClients();
-  await keycloak.selectSupersetId();
-  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).toBeVisible();
-  await keycloak.deleteSyncedRole();
-  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).not.toBeVisible();
-  await delay(30000);
-  await page.getByLabel('Manage').getByRole('link', { name: 'Clients' }).click();
-  await keycloak.selectSupersetId();
-  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).toBeVisible();
-  await superset.deleteRole();
-});
-
 test('A (non-synced) role created from within Keycloak gets deleted in the subsequent polling cycle.', async ({ page }) => {
-  // replay
+  // setup
   await keycloak.open();
   await keycloak.goToClients();
   await keycloak.selectOpenMRSId();
+
+  // replay
   await keycloak.createRole();
 
   // verify

--- a/e2e/tests/keycloak-superset-flows.spec.ts
+++ b/e2e/tests/keycloak-superset-flows.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '@playwright/test';
+import { Keycloak } from '../utils/functions/keycloak';
+import { OpenMRS, delay } from '../utils/functions/openmrs';
+import { Superset, randomSupersetRoleName} from '../utils/functions/superset';
+import { KEYCLOAK_URL } from '../utils/configs/globalSetup';
+
+let openmrs: OpenMRS;
+let keycloak: Keycloak;
+let superset: Superset;
+
+test.beforeEach(async ({ page }) => {
+  openmrs = new OpenMRS(page);
+  keycloak = new Keycloak(page);
+  superset = new Superset(page);
+
+  await openmrs.login();
+  await expect(page).toHaveURL(/.*home/);
+});
+
+test('Creating a Superset role creates the corresponding Keycloak role.', async ({ page }) => {
+  // setup
+  await superset.open();
+
+  // replay
+  await superset.addRole();
+
+  // verify
+  await keycloak.open();
+  await keycloak.goToClients();
+  await keycloak.selectSupersetId();
+  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).toBeVisible();
+  await superset.deleteRole();
+});
+
+test('Updating a synced Superset role updates the corresponding Keycloak role.', async ({ page }) => {
+  // setup
+  await superset.open();
+  await superset.addRole();
+  await keycloak.open();
+  await keycloak.goToClients();
+  await keycloak.selectSupersetId();
+  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).toBeVisible();
+  await expect(page.getByText('')).toBeTruthy();
+
+  // replay
+  await superset.updateRole();
+
+  // verify
+  await page.goto(`${KEYCLOAK_URL}/admin/master/console`);
+  await keycloak.goToClients();
+  await keycloak.selectSupersetId();
+  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).not.toBeVisible();
+  await expect(page.getByText(`${randomSupersetRoleName.updatedRoleName}`)).toBeVisible();
+  await superset.deleteUpdatedRole();
+});
+
+test('Deleting a synced Superset role deletes the corresponding Keycloak role.', async ({ page }) => {
+  // setup
+  await superset.open();
+  await superset.addRole();
+  await keycloak.open();
+  await keycloak.goToClients();
+  await keycloak.selectSupersetId();
+  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).toBeVisible();
+  
+  // replay
+  await superset.deleteRole();
+  await delay(30000);
+
+  // verify
+  await page.goto(`${KEYCLOAK_URL}/admin/master/console`);
+  await keycloak.goToClients();
+  await keycloak.selectSupersetId();
+  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).not.toBeVisible();
+});
+
+test('A synced role deleted from within Keycloak gets recreated in the subsequent polling cycle.', async ({ page }) => {
+  // setup
+  await superset.open();
+  await superset.addRole();
+  await keycloak.open();
+  await keycloak.goToClients();
+  await keycloak.selectSupersetId();
+  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).toBeVisible();
+
+  // replay
+  await keycloak.deleteSyncedRole();
+  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).not.toBeVisible();
+  await delay(30000);
+
+  // verify
+  await page.getByLabel('Manage').getByRole('link', { name: 'Clients' }).click();
+  await keycloak.selectSupersetId();
+  await expect(page.getByText(`${randomSupersetRoleName.roleName}`)).toBeVisible();
+  await superset.deleteRole();
+});
+
+test.afterEach(async ({ page }) => {
+  await page.close();
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "e2e-tests-pro": "npx playwright test",
+    "e2e-tests-pro": "npx playwright test keycloak-openmrs keycloak-superset",
     "e2e-tests-foss": "npx playwright test odoo-openmrs erpnext-openmrs openmrs-senaite"
   },
   "publishConfig": {
@@ -22,7 +22,7 @@
   "keywords": [],
   "author": "",
   "devDependencies": {
-    "@playwright/test": "^1.43.0",
+    "@playwright/test": "^1.44.1",
     "@types/node": "^20.8.10",
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.2.7",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "e2e-tests-pro": "npx playwright test keycloak-openmrs keycloak-superset",
+    "e2e-tests-pro": "npx playwright test",
     "e2e-tests-foss": "npx playwright test odoo-openmrs erpnext-openmrs openmrs-senaite"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,12 @@
 # yarn lockfile v1
 
 
-"@playwright/test@^1.43.0":
-  version "1.43.0"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.43.0.tgz#5d90f247b26d404dd5d81c60f9c7c5e5159eb664"
-  integrity sha512-Ebw0+MCqoYflop7wVKj711ccbNlrwTBCtjY5rlbiY9kHL2bCYxq+qltK6uPsVBGGAOb033H2VO0YobcQVxoW7Q==
+"@playwright/test@^1.44.1":
+  version "1.44.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.44.1.tgz#cc874ec31342479ad99838040e99b5f604299bcb"
+  integrity sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==
   dependencies:
-    playwright "1.43.0"
+    playwright "1.44.1"
 
 "@types/node@^20.8.10":
   version "20.8.10"
@@ -66,17 +66,17 @@ fsevents@2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
-playwright-core@1.43.0:
-  version "1.43.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.43.0.tgz#d8079acb653abebb0b63062e432479647a4e1271"
-  integrity sha512-iWFjyBUH97+pUFiyTqSLd8cDMMOS0r2ZYz2qEsPjH8/bX++sbIJT35MSwKnp1r/OQBAqC5XO99xFbJ9XClhf4w==
+playwright-core@1.44.1:
+  version "1.44.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.44.1.tgz#53ec975503b763af6fc1a7aa995f34bc09ff447c"
+  integrity sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==
 
-playwright@1.43.0:
-  version "1.43.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.43.0.tgz#2c2efd4ee2a25defd8c24c98ccb342bdd9d435f5"
-  integrity sha512-SiOKHbVjTSf6wHuGCbqrEyzlm6qvXcv7mENP+OZon1I07brfZLGdfWV0l/efAzVx7TF3Z45ov1gPEkku9q25YQ==
+playwright@1.44.1:
+  version "1.44.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.44.1.tgz#5634369d777111c1eea9180430b7a184028e7892"
+  integrity sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==
   dependencies:
-    playwright-core "1.43.0"
+    playwright-core "1.44.1"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
Ticket → [OZ-590](https://mekomsolutions.atlassian.net/browse/OZ-590)

This PR refactors E2E test for Keycloak Superset flows into a separate file plus updating playwright  version to 1.44.1

[OZ-590]: https://mekomsolutions.atlassian.net/browse/OZ-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ