### PR TITLE
OZ-541: E2E tests for flows between ERPNext and OpenMRS

### DIFF
--- a/.env
+++ b/.env
@@ -21,8 +21,8 @@ O3_URL_DEMO=https://demo.ozone-his.com
 
 # ERPNEXT
 ERPNEXT_URL_DEV=https://erpnext.ozone-dev.mekomsolutions.net
-ERPNEXT_URL_QA=
-ERPNEXT_URL_DEMO=
+ERPNEXT_URL_QA=https://erpnext.ozone-qa.mekomsolutions.net
+ERPNEXT_URL_DEMO=https://erpnext.demo.ozone-his.com
 
 # Odoo
 ODOO_URL_DEV=https://erp.ozone-dev.mekomsolutions.net

--- a/e2e/tests/erpnext-openmrs-flows.spec.ts
+++ b/e2e/tests/erpnext-openmrs-flows.spec.ts
@@ -151,6 +151,7 @@ test('Revising a synced OpenMRS drug order edits the corresponding ERPNext quota
   await erpnext.searchQuotation();
   await page.getByRole('link', { name: `${patientName.firstName + ' ' + patientName.givenName}` }).click();
   await expect(quantity).toHaveText('8');
+  await erpnext.voidQuotation();
   await openmrs.voidPatient();
   await erpnext.deleteQuotation();
 });

--- a/e2e/tests/erpnext-openmrs-flows.spec.ts
+++ b/e2e/tests/erpnext-openmrs-flows.spec.ts
@@ -18,44 +18,100 @@ test.beforeEach(async ({ page }) => {
 
 test('Ordering a lab test for an OpenMRS patient creates the corresponding ERPNext customer.', async ({ page }) => {
   // replay
-  await openmrs.createLabOrder();
+  await openmrs.goToLabOrderForm();
+  await page.getByPlaceholder('Search for a test type').fill('Blood urea nitrogen');
+  await openmrs.saveLabOrder();
 
   // verify
   await erpnext.open();
   await expect(page).toHaveURL(/.*home/);
   await erpnext.searchCustomer();
-  const customer = await page.locator(".bold a:nth-child(1)");
+  const customer = await page.locator("div.list-row-container:nth-child(3) span:nth-child(2) a");
   await expect(customer).toContainText(`${patientName.firstName + ' ' + patientName.givenName}`);
   await openmrs.voidPatient();
+  await erpnext.deleteQuotation();
 });
 
 test('Ordering a drug for an OpenMRS patient creates the corresponding ERPNext customer with a filled quotation.', async ({ page }) => {
   // replay
-  await openmrs.createDrugOrder();
+  await openmrs.goToDrugOrderForm();
+  await page.getByPlaceholder('Search for a drug or orderset (e.g. "Aspirin")').fill('Aspirin 325mg');
+  await openmrs.fillDrugOrderForm();
+  await openmrs.saveDrugOrder();
 
   // verify
   await erpnext.open();
   await expect(page).toHaveURL(/.*home/);
   await erpnext.searchCustomer();
-  const customer = await page.locator(".bold a:nth-child(1)");
+  const customer = await page.locator("div.list-row-container:nth-child(3) span:nth-child(2) a");
   await expect(customer).toContainText(`${patientName.firstName + ' ' + patientName.givenName}`);
   await page.getByRole('link', { name: `${patientName.firstName + ' ' + patientName.givenName}` }).click();
   await page.locator('#customer-dashboard_tab-tab').click();
   await page.getByLabel('Dashboard').getByText('Quotation').click();
-  await erpnext.searchQuotation();
-  await expect(page.getByText('Draft').nth(0)).toBeVisible();
+  const quotationStatus = await page.locator('div.list-row-container:nth-child(3) div:nth-child(3) span:nth-child(1) span').nth(1);
+  await expect(quotationStatus).toHaveText('Draft');
+  await openmrs.voidPatient();
+  await erpnext.deleteQuotation();
+});
+
+test('Editing the details of an OpenMRS patient with a synced lab order edits the corresponding ERPNext customer details.', async ({ page }) => {
+  // setup
+  await openmrs.goToLabOrderForm();
+  await page.getByPlaceholder('Search for a test type').fill('Blood urea nitrogen');
+  await openmrs.saveLabOrder();
+  await erpnext.open();
+  await erpnext.searchCustomer();
+  const customer = await page.locator("div.list-row-container:nth-child(3) span:nth-child(2) a");
+  await expect(customer).toContainText(`${patientName.firstName + ' ' + patientName.givenName}`);
+
+  // replay
+  await page.goto(`${O3_URL}`);
+  await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await openmrs.updatePatientDetails();
+
+  // verify
+  await page.goto(`${ERPNEXT_URL}/app/home`);
+  await erpnext.searchCustomer();
+  await expect(customer).toContainText(`${patientName.updatedFirstName}` + ' ' + `${patientName.givenName}`);
+  await openmrs.voidPatient();
+  await erpnext.deleteQuotation();
+});
+
+test('Editing the details of an OpenMRS patient with a synced drug order edits the corresponding ERPNext customer details.', async ({ page }) => {
+  // setup
+  await openmrs.goToDrugOrderForm();
+  await page.getByPlaceholder('Search for a drug or orderset (e.g. "Aspirin")').fill('Aspirin 325mg');
+  await openmrs.fillDrugOrderForm();
+  await openmrs.saveDrugOrder();
+  await erpnext.open();
+  await erpnext.searchCustomer();
+  const customer = await page.locator("div.list-row-container:nth-child(3) span:nth-child(2) a");
+  await expect(customer).toContainText(`${patientName.firstName + ' ' + patientName.givenName}`);
+
+  // replay
+  await page.goto(`${O3_URL}`);
+  await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await openmrs.updatePatientDetails();
+
+  // verify
+  await page.goto(`${ERPNEXT_URL}/app/home`);
+  await erpnext.searchCustomer();
+  await expect(customer).toContainText(`${patientName.updatedFirstName}` + ' ' + `${patientName.givenName}`);
   await openmrs.voidPatient();
   await erpnext.deleteQuotation();
 });
 
 test('Ending an OpenMRS patient visit with a synced drug order updates the corresponding ERPNext draft quotation to an open state.', async ({ page }) => {
   // setup
-  await openmrs.createDrugOrder();
+  await openmrs.goToDrugOrderForm();
+  await page.getByPlaceholder('Search for a drug or orderset (e.g. "Aspirin")').fill('Aspirin 325mg');
+  await openmrs.fillDrugOrderForm();
+  await openmrs.saveDrugOrder();
   await erpnext.open();
   await expect(page).toHaveURL(/.*home/);
   await erpnext.searchQuotation();
 
-  const quotationStatus = await page.locator('div.level-left.ellipsis div:nth-child(3) span span');
+  const quotationStatus = await page.locator('div.list-row-container:nth-child(3) div:nth-child(3) span:nth-child(1) span');
   await expect(quotationStatus).toHaveText('Draft');
 
   // replay
@@ -74,7 +130,10 @@ test('Ending an OpenMRS patient visit with a synced drug order updates the corre
 
 test('Revising a synced OpenMRS drug order edits the corresponding ERPNext quotation item.', async ({ page }) => {
   // setup
-  await openmrs.createDrugOrder();
+  await openmrs.goToDrugOrderForm();
+  await page.getByPlaceholder('Search for a drug or orderset (e.g. "Aspirin")').fill('Aspirin 325mg');
+  await openmrs.fillDrugOrderForm();
+  await openmrs.saveDrugOrder();
   await erpnext.open();
   await expect(page).toHaveURL(/.*home/);
   await erpnext.searchQuotation();
@@ -104,7 +163,7 @@ test('Ordering a drug with a free text medication dosage for an OpenMRS patient 
   await erpnext.open();
   await expect(page).toHaveURL(/.*home/);
   await erpnext.searchCustomer();
-  const customer = await page.locator(".bold a:nth-child(1)");
+  const customer = await page.locator("div.list-row-container:nth-child(3) span:nth-child(2) a");
   await expect(customer).toContainText(`${patientName.firstName + ' ' + patientName.givenName}`);
   await page.getByRole('link', { name: `${patientName.firstName + ' ' + patientName.givenName}` }).click();
   await page.locator('#customer-dashboard_tab-tab').click();
@@ -117,7 +176,10 @@ test('Ordering a drug with a free text medication dosage for an OpenMRS patient 
 
 test('Discontinuing a synced OpenMRS drug order for an ERPNext customer with a single quotation line removes the corresponding quotation.', async ({ page }) => {
   // setup
-  await openmrs.createDrugOrder();
+  await openmrs.goToDrugOrderForm();
+  await page.getByPlaceholder('Search for a drug or orderset (e.g. "Aspirin")').fill('Aspirin 325mg');
+  await openmrs.fillDrugOrderForm();
+  await openmrs.saveDrugOrder();
   await erpnext.open();
   await expect(page).toHaveURL(/.*home/);
   await erpnext.searchQuotation();
@@ -134,6 +196,40 @@ test('Discontinuing a synced OpenMRS drug order for an ERPNext customer with a s
   await expect(page.getByText(`${patientName.firstName + ' ' + patientName.givenName}`)).not.toBeVisible();
   await expect(page.getByText('No Quotation found')).toBeVisible();
   await openmrs.voidPatient();
+});
+
+test('Ordering a drug for an OpenMRS patient within a visit creates the corresponding ERPNext customer with a filled quotation linked to the visit.', async ({ page }) => {
+  // setup
+  await openmrs.goToDrugOrderForm();
+  await page.getByPlaceholder('Search for a drug or orderset (e.g. "Aspirin")').fill('Aspirin 325mg');
+  await openmrs.fillDrugOrderForm();
+  await openmrs.saveDrugOrder();
+  await erpnext.open();
+  await erpnext.searchQuotation();
+
+  const firstQuotationStatus = await page.locator('div.list-row-container:nth-child(3) div:nth-child(3) span:nth-child(1) span');
+  await expect(firstQuotationStatus).toHaveText('Draft');
+
+  // replay
+  await page.goto(`${O3_URL}`);
+  await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await openmrs.endPatientVisit();
+  await openmrs.startPatientVisit();
+  await openmrs.goToDrugOrderForm();
+  await page.getByPlaceholder('Search for a drug or orderset (e.g. "Aspirin")').fill('Aspirin 81mg');
+  await openmrs.fillDrugOrderForm();
+  await openmrs.saveDrugOrder();
+
+   // verify
+  await page.goto(`${ERPNEXT_URL}/app/home`);
+  await erpnext.searchQuotation();
+
+  const secondQuotationStatus = await page.locator('div.list-row-container:nth-child(4) div:nth-child(3) span:nth-child(1) span');
+  await expect(firstQuotationStatus).toHaveText('Draft');
+  await expect(secondQuotationStatus).toHaveText('Open');
+  await erpnext.voidQuotation();
+  await openmrs.voidPatient();
+  await erpnext.deleteQuotation();
 });
 
 test.afterEach(async ({ page }) => {

--- a/e2e/tests/odoo-openmrs-flows.spec.ts
+++ b/e2e/tests/odoo-openmrs-flows.spec.ts
@@ -29,7 +29,7 @@ test('Ordering a lab test for an OpenMRS patient creates the corresponding Odoo 
   const customer = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(4)").textContent();
   await expect(customer?.includes(`${patientName.firstName + ' ' + patientName.givenName}`)).toBeTruthy();
 
-  const quotation = await page.locator("table tbody td.o_data_cell:nth-child(8)").textContent();
+  const quotation = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(8) span").textContent();
   await expect(quotation?.includes("Quotation")).toBeTruthy();
 });
 
@@ -43,7 +43,7 @@ test('Editing the details of an OpenMRS patient with a synced lab order edits th
   await odoo.searchCustomer();
   const customer = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(4)").textContent();
   await expect(customer?.includes(`${patientName.firstName + ' ' + patientName.givenName}`)).toBeTruthy();
-  const quotation = await page.locator("table tbody td.o_data_cell:nth-child(8)").textContent();
+  const quotation = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(8) span").textContent();
   await expect(quotation?.includes("Quotation")).toBeTruthy();
   await page.goto(`${O3_URL}`);
   await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
@@ -59,7 +59,10 @@ test('Editing the details of an OpenMRS patient with a synced lab order edits th
 
 test('Ordering a drug for an OpenMRS patient creates the corresponding Odoo customer with a filled quotation.', async ({ page }) => {
   // replay
-  await openmrs.createDrugOrder();
+  await openmrs.goToDrugOrderForm();
+  await page.getByPlaceholder('Search for a drug or orderset (e.g. "Aspirin")').fill('Aspirin 325mg');
+  await openmrs.fillDrugOrderForm();
+  await openmrs.saveDrugOrder();
 
   // verify
   await odoo.open();
@@ -68,19 +71,22 @@ test('Ordering a drug for an OpenMRS patient creates the corresponding Odoo cust
   const customer = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(4)").textContent();
   await expect(customer?.includes(`${patientName.firstName + ' ' + patientName.givenName}`)).toBeTruthy();
 
-  const quotation = await page.locator("table tbody td.o_data_cell:nth-child(8)").textContent();
+  const quotation = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(8) span").textContent();
   await expect(quotation?.includes("Quotation")).toBeTruthy();
 });
 
 test('Editing the details of an OpenMRS patient with a synced drug order edits the corresponding Odoo customer details.', async ({ page }) => {
   // replay
-  await openmrs.createDrugOrder();
+  await openmrs.goToDrugOrderForm();
+  await page.getByPlaceholder('Search for a drug or orderset (e.g. "Aspirin")').fill('Aspirin 325mg');
+  await openmrs.fillDrugOrderForm();
+  await openmrs.saveDrugOrder();
   await odoo.open();
   await expect(page).toHaveURL(/.*web/);
   await odoo.searchCustomer();
   const customer = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(4)").textContent();
   await expect(customer?.includes(`${patientName.firstName + ' ' + patientName.givenName}`)).toBeTruthy();
-  const quotation = await page.locator("table tbody td.o_data_cell:nth-child(8)").textContent();
+  const quotation = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(8) span").textContent();
   await expect(quotation?.includes("Quotation")).toBeTruthy();
   await page.goto(`${O3_URL}`);
   await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
@@ -97,7 +103,10 @@ test('Editing the details of an OpenMRS patient with a synced drug order edits t
 
 test('Revising a synced OpenMRS drug order edits the corresponding Odoo quotation line.', async ({ page }) => {
   // replay
-  await openmrs.createDrugOrder();
+  await openmrs.goToDrugOrderForm();
+  await page.getByPlaceholder('Search for a drug or orderset (e.g. "Aspirin")').fill('Aspirin 325mg');
+  await openmrs.fillDrugOrderForm();
+  await openmrs.saveDrugOrder();
   await odoo.open();
   await expect(page).toHaveURL(/.*web/);
   await odoo.searchCustomer();
@@ -121,13 +130,16 @@ test('Revising a synced OpenMRS drug order edits the corresponding Odoo quotatio
 
 test('Discontinuing a synced OpenMRS drug order for an Odoo customer with a single quotation line removes the corresponding quotation.', async ({ page }) => {
   // replay
-  await openmrs.createDrugOrder();
+  await openmrs.goToDrugOrderForm();
+  await page.getByPlaceholder('Search for a drug or orderset (e.g. "Aspirin")').fill('Aspirin 325mg');
+  await openmrs.fillDrugOrderForm();
+  await openmrs.saveDrugOrder();
   await odoo.open();
   await expect(page).toHaveURL(/.*web/);
   await odoo.searchCustomer();
   const customer = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(4)").textContent();
   await expect(customer?.includes(`${patientName.firstName + ' ' + patientName.givenName}`)).toBeTruthy();
-  const quotation = await page.locator("table tbody td.o_data_cell:nth-child(8)");
+  const quotation = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(8) span");
   await expect(quotation).toHaveText('Quotation');
   await page.getByRole('cell', { name: `${patientName.firstName + ' ' + patientName.givenName}` }).click();
   const drugOrderItem = await page.locator("table tbody td.o_data_cell:nth-child(2) span:nth-child(1) span");
@@ -152,13 +164,16 @@ test('Discontinuing a synced OpenMRS drug order for an Odoo customer with multip
   await page.getByPlaceholder('Search for a test type').fill('Blood urea nitrogen');
   await openmrs.saveLabOrder();
   await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
-  await openmrs.createDrugOrder();
+  await openmrs.goToDrugOrderForm();
+  await page.getByPlaceholder('Search for a drug or orderset (e.g. "Aspirin")').fill('Aspirin 325mg');
+  await openmrs.fillDrugOrderForm();
+  await openmrs.saveDrugOrder();
   await odoo.open();
   await expect(page).toHaveURL(/.*web/);
   await odoo.searchCustomer();
   const customer = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(4)").textContent();
   await expect(customer?.includes(`${patientName.firstName + ' ' + patientName.givenName}`)).toBeTruthy();
-  const quotation = await page.locator("table tbody td.o_data_cell:nth-child(8)");
+  const quotation = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(8) span");
   await expect(quotation).toHaveText('Quotation');
   await page.getByRole('cell', { name: `${patientName.firstName + ' ' + patientName.givenName}` }).click();
   const labOrderItem = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(2) span:nth-child(1) span");
@@ -190,8 +205,32 @@ test('Ordering a drug with a free text medication dosage for an OpenMRS patient 
   const customer = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(4)").textContent();
   await expect(customer?.includes(`${patientName.firstName + ' ' + patientName.givenName}`)).toBeTruthy();
 
-  const quotation = await page.locator("table tbody td.o_data_cell:nth-child(8)").textContent();
+  const quotation = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(8) span").textContent();
   await expect(quotation?.includes("Quotation")).toBeTruthy();
+});
+
+test('Discontinuing a synced OpenMRS lab order for an Odoo customer with a single quotation line cancels the corresponding quotation.', async ({ page }) => {
+  // replay
+  await openmrs.goToLabOrderForm();
+  await page.getByPlaceholder('Search for a test type').fill('Blood urea nitrogen');
+  await openmrs.saveLabOrder();
+  await odoo.open();
+  await expect(page).toHaveURL(/.*web/);
+  await odoo.searchCustomer();
+  const customer = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(4)").textContent();
+  await expect(customer?.includes(`${patientName.firstName + ' ' + patientName.givenName}`)).toBeTruthy();
+  const quotation = await page.locator("tr.o_data_row:nth-child(1) td:nth-child(8) span");
+  await expect(quotation).toHaveText('Quotation');
+
+  await page.goto(`${O3_URL}`);
+  await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await openmrs.cancelLabOrder();
+
+  // verify
+  await page.goto(`${ODOO_URL}`);
+  await odoo.searchCustomer();
+  await expect(customer?.includes(`${patientName.firstName + ' ' + patientName.givenName}`)).toBeTruthy();
+  await expect(quotation).toHaveText('Cancelled');
 });
 
 test.afterEach(async ({ page }) => {

--- a/e2e/utils/functions/openmrs.ts
+++ b/e2e/utils/functions/openmrs.ts
@@ -268,10 +268,12 @@ export class OpenMRS {
     await this.page.getByRole('tab', { name: 'Panel' }).click();
   }
 
-  async createDrugOrder() {
+  async goToDrugOrderForm() {
     await this.page.getByLabel('Order basket', { exact: true }).click();
     await this.page.getByRole('button', { name: 'Add', exact: true }).nth(0).click();
-    await this.page.getByPlaceholder('Search for a drug or orderset (e.g. "Aspirin")').fill('Aspirin 325mg');
+  }
+
+  async fillDrugOrderForm() {
     await this.page.getByRole('button', { name: 'Order form' }).click();
     await delay(2000);
     await this.page.getByPlaceholder('Dose').fill('4');
@@ -284,13 +286,16 @@ export class OpenMRS {
     await this.page.getByLabel('Quantity to dispense').fill('12');
     await this.page.getByLabel('Prescription refills').fill('3');
     await this.page.getByPlaceholder('e.g. "Hypertension"').type('Hypertension');
+  }
+
+  async saveDrugOrder() {
     await this.page.getByRole('button', { name: 'Save order' }).focus();
     await expect(this.page.getByText('Save order')).toBeVisible();
     await this.page.getByRole('button', { name: 'Save order' }).click();
     await this.page.getByRole('button', { name: 'Sign and close' }).focus();
     await expect(this.page.getByText('Sign and close')).toBeVisible();
     await this.page.getByRole('button', { name: 'Sign and close' }).click();
-    await delay(5000);
+    await delay(3000);
   }
 
   async createDrugOrderWithFreeTextDosage() {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "e2e-tests-pro": "npx playwright test erpnext-openmrs",
+    "e2e-tests-pro": "npx playwright test",
     "e2e-tests-foss": "npx playwright test odoo-openmrs erpnext-openmrs openmrs-senaite"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "e2e-tests-pro": "npx playwright test",
+    "e2e-tests-pro": "npx playwright test erpnext-openmrs",
     "e2e-tests-foss": "npx playwright test odoo-openmrs erpnext-openmrs openmrs-senaite"
   },
   "publishConfig": {


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/OZ-541

This PR adds the following E2E tests for the flows between ERPNext and OpenMRS:
- Editing the details of an OpenMRS patient with a synced lab order edits the corresponding ERPNext customer details.
- Editing the details of an OpenMRS patient with a synced drug order edits the corresponding ERPNext customer details.
- Ordering a drug for an OpenMRS patient within a visit creates the corresponding ERPNext customer with a filled quotation linked to the visit.