### PR TITLE
OZ-252: Discontinuing a synced lab order cancels corresponding quotation line in Odoo

### DIFF
--- a/e2e/tests/erpnext-openmrs-flows.spec.ts
+++ b/e2e/tests/erpnext-openmrs-flows.spec.ts
@@ -18,7 +18,9 @@ test.beforeEach(async ({ page }) => {
 
 test('Ordering a lab test for an OpenMRS patient creates the corresponding ERPNext customer.', async ({ page }) => {
   // replay
-  await openmrs.createLabOrder();
+  await openmrs.goToLabOrderForm();
+  await page.getByPlaceholder('Search for a test type').fill('Blood urea nitrogen');
+  await openmrs.saveLabOrder();
 
   // verify
   await erpnext.open();

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "e2e-tests-pro": "npx playwright test odoo-openmrs",
+    "e2e-tests-pro": "npx playwright test",
     "e2e-tests-foss": "npx playwright test odoo-openmrs erpnext-openmrs openmrs-senaite"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "e2e-tests-pro": "npx playwright test",
+    "e2e-tests-pro": "npx playwright test odoo-openmrs",
     "e2e-tests-foss": "npx playwright test odoo-openmrs erpnext-openmrs openmrs-senaite"
   },
   "publishConfig": {


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/OZ-252

This PR adds E2E test verifying that discontinuing a synced OpenMRS lab order for an Odoo customer with a single quotation line cancels the corresponding quotation.