### PR TITLE
OZ-707: E2E tests verifying Odoo groups are synced to Keycloak.

### DIFF
--- a/e2e/tests/keycloak-odoo-flows.spec.ts
+++ b/e2e/tests/keycloak-odoo-flows.spec.ts
@@ -14,7 +14,7 @@ test.beforeEach(async ({ page }) => {
   keycloak = new Keycloak(page);
 });
 
-test('Logging out from Odoo logs out the user from Keycloak.', async ({ page }) => {
+test('Logging out from Odoo ends the session in Keycloak and logs out the user.', async ({ page }) => {
   // setup
   await odoo.open();
   await openmrs.enterLoginCredentials();

--- a/e2e/tests/keycloak-odoo-flows.spec.ts
+++ b/e2e/tests/keycloak-odoo-flows.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test';
-import { KEYCLOAK_URL, ODOO_URL } from '../utils/configs/globalSetup';
-import { Odoo } from '../utils/functions/odoo';
+import { Odoo, randomOdooGroupName } from '../utils/functions/odoo';
 import { OpenMRS } from '../utils/functions/openmrs';
 import { Keycloak } from '../utils/functions/keycloak';
+import { KEYCLOAK_URL, ODOO_URL } from '../utils/configs/globalSetup';
 
 let odoo: Odoo;
 let openmrs: OpenMRS;
@@ -34,12 +34,100 @@ test('Logging out from Odoo logs out the user from Keycloak.', async ({ page }) 
   // verify
   await page.goto(`${KEYCLOAK_URL}/admin/master/console`);
   await keycloak.navigateToClients();
-  await keycloak.selectOpenMRSId();
+  await keycloak.selectOdooId();
   await keycloak.selectSessions();
   await expect(page.locator('h1.pf-c-title:nth-child(2)')).toHaveText(/no sessions/i);
   await expect(page.locator('.pf-c-empty-state__body')).toHaveText(/there are currently no active sessions for this client/i);
   await page.goto(`${ODOO_URL}/web`);
   await expect(page).toHaveURL(/.*login/);
+});
+
+test('Coded Odoo groups create corresponding Keycloak roles.', async ({ page }) => {
+  // setup
+  await page.goto(`${ODOO_URL}`);
+  await odoo.enterLoginCredentials();
+  await expect(page.locator('li.o_user_menu a span')).toHaveText(/administrator/i);
+  await odoo.activateDeveloperMode();
+
+  // replay
+  await odoo.navigateToGroups();
+  await expect(page.getByText('Administration / Settings')).toBeVisible();
+  await expect(page.getByText('Extra Rights / Technical Features')).toBeVisible();
+  await expect(page.getByText('Invoicing / Billing Administrator')).toBeVisible();
+  await expect(page.getByText('Technical / Discount on lines')).toBeVisible();
+  await expect(page.getByText('User types / Portal')).toBeVisible();
+
+  // verify
+  await keycloak.open();
+  await keycloak.navigateToClients();
+  await keycloak.selectOdooId();
+  await keycloak.selectRoles();
+  await page.getByPlaceholder('Search role by name').fill('Administration / Settings');
+  await page.getByRole('button', { name: 'Search' }).press('Enter');
+  await expect(page.getByText('Administration	/ Settings')).toBeVisible();
+  await page.getByPlaceholder('Search role by name').fill('Extra Rights / Technical Features');
+  await page.getByRole('button', { name: 'Search' }).press('Enter');
+  await expect(page.getByText('Extra Rights / Technical Features')).toBeVisible();
+  await page.getByPlaceholder('Search role by name').fill('Invoicing / Billing Administrator');
+  await page.getByRole('button', { name: 'Search' }).press('Enter');
+  await expect(page.getByText('Invoicing / Billing Administrator')).toBeVisible();
+  await page.getByPlaceholder('Search role by name').fill('Technical / Discount on lines');
+  await page.getByRole('button', { name: 'Search' }).press('Enter');
+  await expect(page.getByText('Technical / Discount on lines')).toBeVisible();
+  await page.getByPlaceholder('Search role by name').fill('User types / Portal');
+  await page.getByRole('button', { name: 'Search' }).press('Enter');
+  await expect(page.getByText('User types / Portal')).toBeVisible();
+});
+
+test('Creating an Odoo group creates the corresponding Keycloak role', async ({ page }) => {
+  // setup
+  await page.goto(`${ODOO_URL}`);
+  await odoo.enterLoginCredentials();
+  await expect(page.locator('li.o_user_menu a span')).toHaveText(/administrator/i);
+  await odoo.activateDeveloperMode();
+
+  // replay
+  await odoo.navigateToGroups();
+  await odoo.createGroup();
+
+  // verify
+  await keycloak.open();
+  await keycloak.navigateToClients();
+  await keycloak.selectOdooId();
+  await keycloak.selectRoles();
+  await keycloak.searchOdooRole();
+  await expect(page.locator('tbody:nth-child(2) td:nth-child(1) a')).toHaveText(`Accounting / ${randomOdooGroupName.groupName}`);
+});
+
+test('Updating a synced Odoo group updates the corresponding Keycloak role.', async ({ page }) => {
+  // setup
+  await page.goto(`${ODOO_URL}`);
+  await odoo.enterLoginCredentials();
+  await expect(page.locator('li.o_user_menu a span')).toHaveText(/administrator/i);
+  await odoo.activateDeveloperMode();
+  await odoo.navigateToGroups();
+  await odoo.createGroup();
+  await keycloak.open();
+  await keycloak.navigateToClients();
+  await keycloak.selectOdooId();
+  await keycloak.selectRoles();
+  await keycloak.searchOdooRole();
+  await expect(page.locator('tbody:nth-child(2) td:nth-child(1) a')).toHaveText(`Accounting / ${randomOdooGroupName.groupName}`);
+
+  // replay
+  await page.goto(`${ODOO_URL}`);
+  await odoo.navigateToSettings();
+  await odoo.navigateToGroups();
+  await odoo.searchGroup();
+  await odoo.updateGroup();
+
+  // verify
+  await page.goto(`${KEYCLOAK_URL}/admin/master/console`);
+  await keycloak.navigateToClients();
+  await keycloak.selectOdooId();
+  await keycloak.selectRoles();
+  await keycloak.searchOdooRole();
+  await expect(page.getByText(`Accounting / ${randomOdooGroupName.updatedGroupName}`)).toBeVisible();
 });
 
 test.afterEach(async ({ page }) => {

--- a/e2e/tests/keycloak-openmrs-flows.spec.ts
+++ b/e2e/tests/keycloak-openmrs-flows.spec.ts
@@ -14,7 +14,7 @@ test.beforeEach(async ({ page }) => {
   await expect(page.locator('div:nth-child(1)>a')).toHaveText(/home/i);
 });
 
-test('Logging out from OpenMRS logs out the user from Keycloak.', async ({ page }) => {
+test('Logging out from OpenMRS ends the session in Keycloak and logs out the user.', async ({ page }) => {
   // setup
   await keycloak.open();
   await keycloak.navigateToClients();

--- a/e2e/tests/keycloak-senaite-flows.spec.ts
+++ b/e2e/tests/keycloak-senaite-flows.spec.ts
@@ -14,7 +14,7 @@ test.beforeEach(async ({ page }) => {
   keycloak = new Keycloak(page);
 });
 
-test('Logging out from SENAITE logs out the user from Keycloak.', async ({ page }) => {
+test('Logging out from SENAITE ends the session in Keycloak and logs out the user.', async ({ page }) => {
   // setup
   await senaite.open();
   await openmrs.enterLoginCredentials();

--- a/e2e/tests/keycloak-superset-flows.spec.ts
+++ b/e2e/tests/keycloak-superset-flows.spec.ts
@@ -14,6 +14,34 @@ test.beforeEach(async ({ page }) => {
   superset = new Superset(page);
 });
 
+test('Logging out from Superset logs out the user from Keycloak.', async ({ page }) => {
+  // setup
+  await superset.open();
+  await openmrs.enterLoginCredentials();
+  await expect(page).toHaveURL(/.*superset/);
+  await expect(page.locator('#app div.header')).toHaveText(/home/i);
+  await keycloak.open();
+  await keycloak.navigateToClients();
+  await keycloak.selectSupersetId();
+  await keycloak.selectSessions();
+  await expect(page.locator('td:nth-child(1) a').nth(0)).toHaveText(/jdoe/i);
+
+  // replay
+  await superset.logout();
+  await keycloak.confirmLogout();
+  await expect(page).toHaveURL(/.*login/);
+
+  // verify
+  await page.goto(`${KEYCLOAK_URL}/admin/master/console`);
+  await keycloak.navigateToClients();
+  await keycloak.selectSupersetId();
+  await keycloak.selectSessions();
+  await expect(page.locator('h1.pf-c-title:nth-child(2)')).toHaveText(/no sessions/i);
+  await expect(page.locator('.pf-c-empty-state__body')).toHaveText(/there are currently no active sessions for this client/i);
+  await page.goto(`${SUPERSET_URL}/superset/welcome`);
+  await expect(page).toHaveURL(/.*login/);
+});
+
 test('Creating a Superset role creates the corresponding Keycloak role.', async ({ page }) => {
   // setup
   await openmrs.login();
@@ -109,34 +137,6 @@ test('A synced role deleted from within Keycloak gets recreated in the subsequen
   await expect(page.locator('tbody:nth-child(2) td:nth-child(1) a')).toHaveText(`${randomSupersetRoleName.roleName}`);
   await superset.deleteRole();
   await superset.logout();
-});
-
-test('Logging out from Superset logs out the user from Keycloak.', async ({ page }) => {
-  // setup
-  await superset.open();
-  await openmrs.enterLoginCredentials();
-  await expect(page).toHaveURL(/.*superset/);
-  await expect(page.locator('#app div.header')).toHaveText(/home/i);
-  await keycloak.open();
-  await keycloak.navigateToClients();
-  await keycloak.selectSupersetId();
-  await keycloak.selectSessions();
-  await expect(page.locator('td:nth-child(1) a').nth(0)).toHaveText(/jdoe/i);
-
-  // replay
-  await superset.logout();
-  await keycloak.confirmLogout();
-  await expect(page).toHaveURL(/.*login/);
-
-  // verify
-  await page.goto(`${KEYCLOAK_URL}/admin/master/console`);
-  await keycloak.navigateToClients();
-  await keycloak.selectSupersetId();
-  await keycloak.selectSessions();
-  await expect(page.locator('h1.pf-c-title:nth-child(2)')).toHaveText(/no sessions/i);
-  await expect(page.locator('.pf-c-empty-state__body')).toHaveText(/there are currently no active sessions for this client/i);
-  await page.goto(`${SUPERSET_URL}/superset/welcome`);
-  await expect(page).toHaveURL(/.*login/);
 });
 
 test.afterEach(async ({ page }) => {

--- a/e2e/tests/keycloak-superset-flows.spec.ts
+++ b/e2e/tests/keycloak-superset-flows.spec.ts
@@ -14,7 +14,7 @@ test.beforeEach(async ({ page }) => {
   superset = new Superset(page);
 });
 
-test('Logging out from Superset logs out the user from Keycloak.', async ({ page }) => {
+test('Logging out from Superset ends the session in Keycloak and logs out the user.', async ({ page }) => {
   // setup
   await superset.open();
   await openmrs.enterLoginCredentials();

--- a/e2e/utils/functions/keycloak.ts
+++ b/e2e/utils/functions/keycloak.ts
@@ -2,6 +2,7 @@ import { Page, expect } from '@playwright/test';
 import { KEYCLOAK_URL } from '../configs/globalSetup';
 import { randomSupersetRoleName } from './superset';
 import { delay, randomOpenMRSRoleName } from './openmrs';
+import { randomOdooGroupName } from './odoo';
 
 export var randomKeycloakRoleName = {
   roleName : `${(Math.random() + 1).toString(36).substring(2)}`
@@ -79,6 +80,12 @@ export class Keycloak {
   async searchSupersetRole() {
     await expect(this.page.getByPlaceholder('Search role by name')).toBeVisible();
     await this.page.getByPlaceholder('Search role by name').fill(`${randomSupersetRoleName.roleName}`);
+    await this.page.getByRole('button', { name: 'Search' }).press('Enter');
+  }
+
+  async searchOdooRole() {
+    await expect(this.page.getByPlaceholder('Search role by name')).toBeVisible();
+    await this.page.getByPlaceholder('Search role by name').fill(`${randomOdooGroupName.groupName}`);
     await this.page.getByRole('button', { name: 'Search' }).press('Enter');
   }
 

--- a/e2e/utils/functions/openmrs.ts
+++ b/e2e/utils/functions/openmrs.ts
@@ -11,7 +11,7 @@ export var patientName = {
 var patientFullName = '';
 
 export var randomOpenMRSRoleName = {
-  roleName : `${(Math.random() + 1).toString(36).substring(2)}`
+  roleName : `${Array.from({ length: 8 }, () => String.fromCharCode(Math.floor(Math.random() * 26) + 97)).join('')}`
 }
 
 export const delay = (mills) => {
@@ -373,7 +373,7 @@ export class OpenMRS {
     await this.page.getByLabel('Organizational: Registration Clerk').check();
     await this.page.getByRole('button', { name: 'Save Role' }).click();
     await expect(this.page.getByText('Role saved')).toBeVisible();
-    await delay(50000);
+    await delay(160000);
   }
 
   async updateRole() {
@@ -384,7 +384,7 @@ export class OpenMRS {
     await this.page.getByLabel('Application: Writes Clinical Notes').check();
     await this.page.getByRole('button', { name: 'Save Role' }).click();
     await expect(this.page.getByText('Role saved')).toBeVisible();
-    await delay(50000);
+    await delay(160000);
   }
 
   async unlinkInheritedRoles() {

--- a/e2e/utils/functions/superset.ts
+++ b/e2e/utils/functions/superset.ts
@@ -4,8 +4,8 @@ import { delay } from './openmrs';
 import { Keycloak } from './keycloak';
 
 export var randomSupersetRoleName = {
-  roleName : `${(Math.random() + 1).toString(36).substring(2)}`,
-  updatedRoleName : `${(Math.random() + 1).toString(36).substring(2)}`
+  roleName : `${Array.from({ length: 8 }, () => String.fromCharCode(Math.floor(Math.random() * 26) + 97)).join('')}`,
+  updatedRoleName : `${Array.from({ length: 8 }, () => String.fromCharCode(Math.floor(Math.random() * 26) + 97)).join('')}`
 }
 
 export class Superset {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "ozone-pro": "npx playwright test",
+    "ozone-pro": "npx playwright test keycloak-odoo",
     "ozone-foss": "npx playwright test odoo-openmrs erpnext-openmrs openmrs-senaite",
     "openmrs-distro-his": "npx playwright test odoo-openmrs openmrs-senaite"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "ozone-pro": "npx playwright test keycloak-odoo",
+    "ozone-pro": "npx playwright test",
     "ozone-foss": "npx playwright test odoo-openmrs erpnext-openmrs openmrs-senaite",
     "openmrs-distro-his": "npx playwright test odoo-openmrs openmrs-senaite"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ dotenv.config();
 
 const config: PlaywrightTestConfig = {
   testDir: './e2e/tests',
-  timeout: 3 * 60 * 1000,
+  timeout: 10 * 60 * 1000,
   expect: {
     timeout: 40 * 1000,
   },


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/OZ-707

This PR adds E2E tests for the flows between Keycloak and Odoo.
- Existing Odoo groups create the corresponding Keycloak role.
- Creating new group in Odoo creates the role in Keycloak.
- Renaming a group in Odoo updates the corresponding role in Keycloak.