### PR TITLE
OZ-711: Modifying the details of a sale order in Odoo should update the respective entry in Superset's sale_order_lines table.

### DIFF
--- a/e2e/tests/keycloak-odoo-flows.spec.ts
+++ b/e2e/tests/keycloak-odoo-flows.spec.ts
@@ -80,6 +80,7 @@ test('Coded Odoo groups create corresponding Keycloak roles.', async ({ page }) 
 
 test('Creating an Odoo group creates the corresponding Keycloak role', async ({ page }) => {
   // setup
+  test.setTimeout(360000);
   await page.goto(`${ODOO_URL}`);
   await odoo.enterLoginCredentials();
   await expect(page.locator('li.o_user_menu a span')).toHaveText(/administrator/i);
@@ -100,6 +101,7 @@ test('Creating an Odoo group creates the corresponding Keycloak role', async ({ 
 
 test('Updating a synced Odoo group updates the corresponding Keycloak role.', async ({ page }) => {
   // setup
+  test.setTimeout(720000);
   await page.goto(`${ODOO_URL}`);
   await odoo.enterLoginCredentials();
   await expect(page.locator('li.o_user_menu a span')).toHaveText(/administrator/i);
@@ -131,6 +133,7 @@ test('Updating a synced Odoo group updates the corresponding Keycloak role.', as
 
 test('Deleting a synced Odoo group deletes the corresponding Keycloak role.', async ({ page }) => {
   // setup
+  test.setTimeout(720000);
   await page.goto(`${ODOO_URL}`);
   await odoo.enterLoginCredentials();
   await expect(page.locator('li.o_user_menu a span')).toHaveText(/administrator/i);

--- a/e2e/tests/keycloak-openmrs-flows.spec.ts
+++ b/e2e/tests/keycloak-openmrs-flows.spec.ts
@@ -38,6 +38,7 @@ test('Logging out from OpenMRS ends the session in Keycloak and logs out the use
 
 test('Creating an OpenMRS role creates the corresponding Keycloak role.', async ({ page }) => {
   // setup
+  test.setTimeout(240000);
   await page.goto(`${O3_URL}/openmrs/admin/users/role.list`);
 
   // replay
@@ -62,6 +63,7 @@ test('Creating an OpenMRS role creates the corresponding Keycloak role.', async 
 
 test('Updating a synced OpenMRS role updates the corresponding Keycloak role.', async ({ page }) => {
   // setup
+  test.setTimeout(420000);
   await page.goto(`${O3_URL}/openmrs/admin/users/role.list`);
   await openmrs.addRole();
   await keycloak.open();
@@ -98,6 +100,7 @@ test('Updating a synced OpenMRS role updates the corresponding Keycloak role.', 
 
 test('Deleting a synced OpenMRS role deletes the corresponding Keycloak role.', async ({ page }) => {
   // setup
+  test.setTimeout(420000);
   await page.goto(`${O3_URL}/openmrs/admin/users/role.list`);
   await openmrs.addRole();
   await keycloak.open();

--- a/e2e/tests/keycloak-senaite-flows.spec.ts
+++ b/e2e/tests/keycloak-senaite-flows.spec.ts
@@ -28,7 +28,6 @@ test('Logging out from SENAITE ends the session in Keycloak and logs out the use
 
   // replay
   await senaite.logout();
-  await keycloak.confirmLogout();
   await expect(page.locator('#username')).toBeVisible();
 
   // verify

--- a/e2e/tests/odoo-superset-flows.spec.ts
+++ b/e2e/tests/odoo-superset-flows.spec.ts
@@ -62,7 +62,7 @@ test(`Creating an Odoo sale order line generates an entry in Superset's sale_ord
   await expect(unitPrice).toBe(2);
 });
 
-test(`Revising an Odoo sale order line modifies the corresponding entry in Superset's sale_order_lines table.`, async ({ page }) => {
+test(`Revising an Odoo sale order line updates the corresponding entry in Superset's sale_order_lines table.`, async ({ page }) => {
   // setup
   await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
   await openmrs.navigateToLabOrderForm();
@@ -146,7 +146,7 @@ test(`Voiding an Odoo sale order line updates the corresponding entry in Superse
   await expect(page.locator('div.virtual-table-cell:nth-child(4)')).toHaveText('0');
 });
 
-test(`Deleting an Odoo quotation line removes the corresponding entry in Superset's sale_order_lines table.`, async ({ page }) => {
+test(`Deleting an Odoo quotation line deletes the corresponding entry in Superset's sale_order_lines table.`, async ({ page }) => {
   // setup
   await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
   await openmrs.navigateToLabOrderForm();

--- a/e2e/tests/openmrs-superset-flows.spec.ts
+++ b/e2e/tests/openmrs-superset-flows.spec.ts
@@ -84,7 +84,7 @@ test(`Creating an OpenMRS visit creates the visit in Superset's visits table.`, 
   await expect(page.locator('div.virtual-table-cell:nth-child(3)')).toHaveText('Inpatient Ward');
   await expect(page.locator('div.virtual-table-cell:nth-child(6)')).toHaveText('Facility Visit');
   await expect(page.locator('div.virtual-table-cell:nth-child(8)')).toHaveText('M');
-  await expect(page.locator('div.virtual-table-cell:nth-child(10)')).toHaveText('true')
+  await expect(page.locator('div.virtual-table-cell:nth-child(2)')).toHaveText('false')
   await page.getByRole('tab', { name: 'Query history' }).click();
   await superset.clearSQLEditor();
   await openmrs.voidPatient();

--- a/e2e/utils/functions/odoo.ts
+++ b/e2e/utils/functions/odoo.ts
@@ -41,7 +41,7 @@ export class Odoo {
   }
 
   async createSaleOrderLine() {
-    await this.page.getByRole('button', { name: 'Create' }).click();
+    await this.page.getByRole('button', { name: /create/i }).click();
     await expect(this.page.locator('li.breadcrumb-item:nth-child(2)')).toHaveText(/new/i);
     await this.page.getByLabel('Customer', { exact: true }).type(`${patientName.firstName + ' ' + patientName.givenName}`);
     await this.page.getByText(`${patientName.firstName + ' ' + patientName.givenName}`).first().click();
@@ -52,11 +52,51 @@ export class Odoo {
     await this.page.locator('td.o_data_cell:nth-child(7) input').fill('2.00');
     await this.page.locator('td.o_data_cell:nth-child(9)').click(), delay(2000);
     await expect(this.page.locator('td.o_data_cell:nth-child(9)')).toHaveText('$ 16.00');
-    await this.page.getByRole('button', { name: 'Confirm' }).click(), delay(3000);
+    await this.page.getByRole('button', { name: /confirm/i }).click(), delay(3000);
     await expect(this.page.locator('td.o_data_cell:nth-child(2) span:nth-child(1) span')).toHaveText('Acétaminophene Co 500mg');
     await expect(this.page.locator('td.o_data_cell:nth-child(4)')).toHaveText('8');
     await expect(this.page.locator('td.o_data_cell:nth-child(9)')).toHaveText('2.00');
     await expect(this.page.locator('td.o_data_cell:nth-child(11)')).toHaveText('$ 16.00');
+  }
+
+  async createQuotationLine() {
+    await this.page.getByRole('button', { name: /create/i }).click();
+    await expect(this.page.locator('li.breadcrumb-item:nth-child(2)')).toHaveText(/new/i);
+    await this.page.getByLabel('Customer', { exact: true }).type(`${patientName.firstName + ' ' + patientName.givenName}`);
+    await this.page.getByText(`${patientName.firstName + ' ' + patientName.givenName}`).first().click();
+    await this.page.getByRole('button', { name: 'Add a product' }).click();
+    await this.page.locator('td.o_data_cell:nth-child(2) div:nth-child(1) input').fill('Acyclovir Sirop 200mg');
+    await this.page.getByText('Acyclovir Sirop 200mg').first().click();
+    await this.page.locator('input[name="product_uom_qty"]').fill('6');
+    await this.page.locator('td.o_data_cell:nth-child(7) input').fill('2.00');
+    await this.page.locator('td.o_data_cell:nth-child(9)').click(), delay(2000);
+    await expect(this.page.locator('td.o_data_cell:nth-child(9)')).toHaveText('$ 12.00');
+    await this.page.getByRole('button', { name: /save/i }).click(), delay(3000);
+    await expect(this.page.locator('td.o_data_cell:nth-child(2) span:nth-child(1) span')).toHaveText('Acyclovir Sirop 200mg');
+  }
+
+  async modifySaleOrderLine() {
+    await this.page.getByRole('button', { name: /edit/i }).click();
+    await this.page.getByText(/acétaminophene co 500mg/i).nth(1).click();
+    await this.page.locator('input[name="product_uom_qty"]').fill('10');
+    await this.page.locator('input[name="price_unit"]').fill('3');
+    await this.page.locator('td.o_field_x2many_list_row_add').click(), delay(2000);
+    await expect(this.page.locator('td.o_data_cell:nth-child(11)')).toHaveText('$ 30.00');
+    await this.page.getByRole('button', { name: /save/i }).click(), delay(3000);
+  }
+
+  async voidSaleOrderLine() {
+    await this.page.getByRole('button', { name: /edit/i }).click();
+    await this.page.getByText(/acétaminophene co 500mg/i).nth(1).click();
+    await this.page.locator('input[name="product_uom_qty"]').fill('0');
+    await this.page.getByRole('button', { name: /save/i }).click(), delay(1000);
+    await this.page.getByRole('button', { name: 'Ok' }).click(), delay(3000);
+  }
+
+  async deleteQuotationLine() {
+    await this.page.getByRole('button', { name: /edit/i }).click();
+    await this.page.getByRole('cell', { name: /delete row/i }).click();
+    await this.page.getByRole('button', { name: /save/i }).click(), delay(3000);
   }
 
   async activateDeveloperMode() {

--- a/e2e/utils/functions/openmrs.ts
+++ b/e2e/utils/functions/openmrs.ts
@@ -50,7 +50,7 @@ export class OpenMRS {
     await this.page.locator('#username').fill(`${process.env.OZONE_USERNAME}`);
     await this.page.getByRole('button', { name: /continue/i }).click();
     await this.page.locator('#password').fill(`${process.env.OZONE_PASSWORD}`);
-    await this.page.getByRole('button', { name: /sign in/ }).click();
+    await this.page.getByRole('button', { name: /sign in/i }).click();
   }
 
   async createPatient() {
@@ -68,10 +68,8 @@ export class OpenMRS {
     await this.page.locator('div[aria-label="day, "]').fill('16');
     await this.page.locator('div[aria-label="month, "]').fill('08');
     await this.page.locator('div[aria-label="year, "]').fill('2002');
-    await this.page.getByRole('button', { name: /register patient/i }).click();
     await this.createPatientButton().click();
     await expect(this.page.getByText(/new patient created/i)).toBeVisible(), delay(3000);;
-    await this.page.getByRole('button', { name: 'Close', exact: true }).click();
   }
 
   async goToHomePage() {
@@ -178,7 +176,7 @@ export class OpenMRS {
 
   async addPatientAppointment() {
     await this.page.getByRole('link', { name: /appointments/i }).click();
-    await this.page.getByRole('button', { name: /add/i, exact: true }).click();
+    await this.page.getByRole('button', { name: 'Add', exact: true }).click();
     await this.page.getByLabel(/select a service/i).selectOption('General Medicine service');
     await this.page.getByLabel(/select an appointment type/i).selectOption('Scheduled');
     await this.page.locator('#duration').fill('40');
@@ -202,8 +200,8 @@ export class OpenMRS {
 
   async navigateToLabOrderForm() {
     await this.page.getByLabel(/order basket/i).click(), delay(2000);
-    await expect(this.page.getByRole('button', { name: /add/i, exact: true }).nth(1)).toBeVisible();
-    await this.page.getByRole('button', { name: /add/i, exact: true }).nth(1).click();
+    await expect(this.page.getByRole('button', { name: 'Add', exact: true }).nth(1)).toBeVisible();
+    await this.page.getByRole('button', { name: 'Add', exact: true }).nth(1).click();
   }
 
   async saveLabOrder() {
@@ -227,8 +225,7 @@ export class OpenMRS {
     await this.page.getByRole('button', { name: /options/i, exact: true }).click();
     await this.page.getByRole('menuitem', { name: /delete this encounter/i }).click();
     await this.page.getByRole('button', { name: /danger delete/i }).click();
-    await expect(this.page.getByText(/encounter deleted/i)).toBeVisible();
-    await expect(this.page.getByText(/encounter successfully deleted/i)).toBeVisible(), delay(5000);
+    await expect(this.page.getByText(/encounter deleted/i)).toBeVisible(), delay(5000);
   }
 
   async cancelLabOrder() {
@@ -248,8 +245,8 @@ export class OpenMRS {
   async navigateToDrugOrderForm() {
     await expect(this.page.getByLabel(/order basket/i)).toBeVisible();
     await this.page.getByLabel(/order basket/i).click(), delay(2000);
-    await expect(this.page.getByRole('button', { name: /add/i, exact: true }).nth(0)).toBeVisible();
-    await this.page.getByRole('button', { name: /add/i, exact: true }).nth(0).click();
+    await expect(this.page.getByRole('button', { name: 'Add', exact: true }).nth(0)).toBeVisible();
+    await this.page.getByRole('button', { name: 'Add', exact: true }).nth(0).click();
   }
 
   async fillDrugOrderForm() {
@@ -278,7 +275,7 @@ export class OpenMRS {
   async createDrugOrderWithFreeTextDosage() {
     await expect(this.page.getByLabel(/order basket/i)).toBeVisible();
     await this.page.getByLabel(/order basket/i).click(), delay(2000);
-    await expect(this.page.getByRole('button', { name: /add/i, exact: true }).nth(0)).toBeVisible();
+    await expect(this.page.getByRole('button', { name: 'Add', exact: true }).nth(0)).toBeVisible();
     await this.page.getByRole('button', { name: 'Add', exact: true }).nth(0).click();
     await this.page.getByRole('searchbox').fill('Aspirin 325mg');
     await this.page.getByRole('button', { name: 'Order form' }).click();

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "ozone-pro": "npx playwright test odoo-superset",
+    "ozone-pro": "npx playwright test",
     "ozone-foss": "npx playwright test odoo-openmrs erpnext-openmrs openmrs-senaite",
     "openmrs-distro-his": "npx playwright test odoo-openmrs openmrs-senaite"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "ozone-pro": "npx playwright test",
+    "ozone-pro": "npx playwright test odoo-superset",
     "ozone-foss": "npx playwright test odoo-openmrs erpnext-openmrs openmrs-senaite",
     "openmrs-distro-his": "npx playwright test odoo-openmrs openmrs-senaite"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ dotenv.config();
 
 const config: PlaywrightTestConfig = {
   testDir: './e2e/tests',
-  timeout: 10 * 60 * 1000,
+  timeout: 3 * 60 * 1000,
   expect: {
     timeout: 40 * 1000,
   },


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/OZ-711

This PR adds tests for Odoo → Analytics streaming and covers the following scenarios.
 - Revising an Odoo sale order line modifies the corresponding entry in Superset's sale_order_lines table.
 - Voiding an Odoo sale order line updates the corresponding entry in Superset's sale_order_lines table.
 - Deleting an Odoo quotation line removes the corresponding entry in Superset's sale_order_lines table. 