### PR TITLE
OZ-831: Add e2e tests for OpenMRS ← Orthanc flows

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@
 
 # The target environment that will be tested.
 # Possible values are dev, qa, demo.
-TEST_ENVIRONMENT=dev
+TEST_ENVIRONMENT=demo
 
 # Set to true to test Ozone Pro, false to test Ozone FOSS.
 TEST_PRO=true
@@ -28,6 +28,11 @@ ERPNEXT_URL_DEMO=https://erpnext.demo.ozone-his.com
 ODOO_URL_DEV=https://erp.ozone-dev.mekomsolutions.net
 ODOO_URL_QA=https://erp.ozone-qa.mekomsolutions.net
 ODOO_URL_DEMO=https://erp.demo.ozone-his.com
+
+# Orthanc
+ORTHANC_URL_DEV=https://pacs.ozone-dev.mekomsolutions.net
+ORTHANC_URL_QA=https://pacs.ozone-qa.mekomsolutions.net
+ORTHANC_URL_DEMO=https://pacs.demo.ozone-his.com
 
 # SENAITE
 SENAITE_URL_DEV=https://lims.ozone-dev.mekomsolutions.net
@@ -55,6 +60,10 @@ O3_PASSWORD_ON_FOSS=Admin123
 # ERPNext test user credentials
 ERPNEXT_USERNAME=Administrator
 ERPNEXT_PASSWORD=password
+
+# Orthanc test user credentials
+ORTHANC_USERNAME=orthanc
+ORTHANC_PASSWORD=orthanc
 
 # Odoo test user credentials for FOSS
 ODOO_USERNAME_ON_FOSS=admin

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,13 +48,6 @@ jobs:
         with:
           node-version: 20
 
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-
       - name: Install dependencies
         run: yarn install
 

--- a/.github/workflows/pro.yml
+++ b/.github/workflows/pro.yml
@@ -33,13 +33,6 @@ jobs:
         with:
           node-version: 20
 
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-
       - name: Install dependencies
         run: yarn install
 

--- a/e2e/tests/openmrs-orthanc-flows.spec.ts
+++ b/e2e/tests/openmrs-orthanc-flows.spec.ts
@@ -1,0 +1,46 @@
+import { expect } from '@playwright/test';
+import { O3_URL, ORTHANC_URL, test } from '../utils/configs/globalSetup';
+import { OpenMRS, patientName } from '../utils/functions/openmrs';
+import { Orthanc } from '../utils/functions/orthanc';
+
+let openmrs: OpenMRS;
+let orthanc: Orthanc;
+
+test.beforeEach(async ({ orthancPage }) => {
+  openmrs = new OpenMRS(orthancPage);
+  orthanc = new Orthanc(orthancPage);
+
+  await openmrs.login();
+});
+
+test('Uploading a DICOM study in Orthanc creates the corresponding radiology image for the OpenMRS patient.', async ({ page, context, orthancPage }) => {
+  // setup
+  await openmrs.createPatient();
+  await openmrs.navigateToAttachments();
+  await expect(orthancPage.getByText(/there are no attachments to display for this patient/i)).toBeVisible();
+  await openmrs.searchPatientId();
+  const patientIdentifier = await orthancPage.locator('[data-testid="identifier-placeholder"]').textContent();
+
+  // replay
+  await orthanc.open();
+  await expect(orthancPage.locator('#lookup').getByText('Orthanc server')).toBeVisible();
+  await orthancPage.goto(`${ORTHANC_URL}/ui/app/index.html`);
+  await orthanc.uploadAttachments();
+  await expect(orthancPage.locator('text=VIX - Extrémités')).toBeVisible();
+  await expect(orthancPage.locator('text=Uploaded studies')).toBeVisible();
+  await orthanc.navigateToImageStudyForm();
+  await orthancPage.locator("//div[text()='OtherPatientIDs']/following::input[1]").fill(`${patientIdentifier}`);
+  await orthanc.clickOnModifyButton();
+
+  // verify
+  await orthancPage.goto(`${O3_URL}`);
+  await openmrs.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await openmrs.navigateToAttachments();
+  await expect(orthancPage.getByText(/radiology-image/i)).toBeVisible();
+  await orthancPage.getByLabel(/table view/i).click();
+  await expect(orthancPage.getByText(/radiology-image/i)).toBeVisible();
+});
+
+test.afterEach(async ({}) => {
+  await orthanc.removeAttachments();
+});

--- a/e2e/utils/configs/globalSetup.ts
+++ b/e2e/utils/configs/globalSetup.ts
@@ -14,6 +14,7 @@ dotenv.config();
 export const O3_URL = `${process.env.TEST_ENVIRONMENT}` == 'demo' ? `${process.env.O3_URL_DEMO}` : `${process.env.TEST_ENVIRONMENT}` == 'qa' ? `${process.env.O3_URL_QA}`: `${process.env.O3_URL_DEV}`;
 export const ERPNEXT_URL = `${process.env.TEST_ENVIRONMENT}` == 'demo' ? `${process.env.ERPNEXT_URL_DEMO}` : `${process.env.TEST_ENVIRONMENT}` == 'qa' ? `${process.env.ERPNEXT_URL_QA}`: `${process.env.ERPNEXT_URL_DEV}`;
 export const ODOO_URL = `${process.env.TEST_ENVIRONMENT}` == 'demo' ? `${process.env.ODOO_URL_DEMO}` : `${process.env.TEST_ENVIRONMENT}` == 'qa' ? `${process.env.ODOO_URL_QA}`: `${process.env.ODOO_URL_DEV}`;
+export const ORTHANC_URL = `${process.env.TEST_ENVIRONMENT}` == 'demo' ? `${process.env.ORTHANC_URL_DEMO}` : `${process.env.TEST_ENVIRONMENT}` == 'qa' ? `${process.env.ORTHANC_URL_QA}`: `${process.env.ORTHANC_URL_DEV}`;
 export const SENAITE_URL = `${process.env.TEST_ENVIRONMENT}` == 'demo' ? `${process.env.SENAITE_URL_DEMO}` : `${process.env.TEST_ENVIRONMENT}` == 'qa' ? `${process.env.SENAITE_URL_QA}`: `${process.env.SENAITE_URL_DEV}`;
 export const KEYCLOAK_URL = `${process.env.TEST_ENVIRONMENT}` == 'demo' ? `${process.env.KEYCLOAK_URL_DEMO}` : `${process.env.TEST_ENVIRONMENT}` == 'qa' ? `${process.env.KEYCLOAK_URL_QA}`: `${process.env.KEYCLOAK_URL_DEV}`;
 export const SUPERSET_URL = `${process.env.TEST_ENVIRONMENT}` == 'demo' ? `${process.env.SUPERSET_URL_DEMO}` : `${process.env.TEST_ENVIRONMENT}` == 'qa' ? `${process.env.SUPERSET_URL_QA}`: `${process.env.SUPERSET_URL_DEV}`;
@@ -51,6 +52,7 @@ export const api: WorkerFixture<APIRequestContext, PlaywrightWorkerArgs> = async
 
 export interface CustomTestFixtures {
   loginAsAdmin: Page;
+  orthancPage: Page;
 }
 
 export interface CustomWorkerFixtures {
@@ -59,6 +61,17 @@ export interface CustomWorkerFixtures {
 
 export const test = base.extend<CustomTestFixtures, CustomWorkerFixtures>({
   api: [api, { scope: 'worker' }],
+  orthancPage: async ({ browser }, use) => {
+    const context = await browser.newContext({
+      httpCredentials: {
+        username: process.env.ORTHANC_USERNAME || '',
+        password: process.env.ORTHANC_PASSWORD || '',
+      },
+    });
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  },
 });
 
 export default globalSetup;

--- a/e2e/utils/functions/openmrs.ts
+++ b/e2e/utils/functions/openmrs.ts
@@ -198,6 +198,10 @@ export class OpenMRS {
     await expect(this.page.getByText(/appointment cancelled successfully/i)).toBeVisible();
    }
 
+   async navigateToAttachments() {
+    await (this.page.getByRole('link', { name: /attachments/i })).click();
+  }
+
   async navigateToLabOrderForm() {
     await this.page.getByLabel(/order basket/i).click(), delay(2000);
     await expect(this.page.getByRole('button', { name: 'Add', exact: true }).nth(1)).toBeVisible();

--- a/e2e/utils/functions/orthanc.ts
+++ b/e2e/utils/functions/orthanc.ts
@@ -1,0 +1,38 @@
+import { expect, Page } from '@playwright/test';
+import { ORTHANC_URL } from '../configs/globalSetup';
+import { delay } from './openmrs';
+
+  export class Orthanc {
+    constructor(readonly page: Page) {}
+
+    async open() {
+      await this.page.goto(`${ORTHANC_URL}`);
+    }
+
+    async navigateToImageStudyForm() {
+      await this.page.getByText('VIX', {exact: true}).nth(0).click();
+      await expect(this.page.locator('i[title="Modify"]')).toBeVisible();
+      await this.page.locator('i[title="Modify"]').click();
+      await this.page.getByRole('button', { name: 'Modify Study tags' }).click();
+      await this.page.getByRole('radio', { name: 'Modify the original study. (keeping the original DICOM UIDs)' }).check();
+      await this.page.locator("//div[text()='OtherPatientIDs']/following::input[1]").clear();
+    }
+
+    async clickOnModifyButton() {
+      await this.page.getByRole('button', { name: 'Modify' }).click(), delay(10000);
+    }
+
+    async uploadAttachments() {
+      await this.page.getByText('Upload', { exact: true }).click();
+      const filePath = './e2e/utils/support/upload/imageStudy.zip';
+      const fileInput = this.page.locator('#filesUpload');
+      await fileInput.setInputFiles(filePath), delay(20000);
+    }
+
+    async removeAttachments() {
+      await this.page.goto(`${ORTHANC_URL}/ui/app/index.html`);
+      await this.page.getByRole('row', { name: 'VIX' }).getByRole('checkbox').check();
+      await this.page.locator('//i[@title="Delete"]').click();
+      await this.page.getByRole('button', { name: /delete/i }).click();
+    }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "ozone-pro": "npx playwright test",
+    "ozone-pro": "npx playwright test orthanc",
     "ozone-foss": "npx playwright test odoo-openmrs erpnext-openmrs openmrs-senaite",
     "openmrs-distro-his": "npx playwright test odoo-openmrs openmrs-senaite"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ const config: PlaywrightTestConfig = {
   expect: {
     timeout: 40 * 1000,
   },
-  fullyParallel: true,
+  fullyParallel: false,
   forbidOnly: !!process.env.CI,
   workers: process.env.CI ? 1 : 1,
   retries: 0,
@@ -17,7 +17,6 @@ const config: PlaywrightTestConfig = {
   globalSetup: require.resolve('./e2e/utils/configs/globalSetup'),
   use: {
     baseURL: `${O3_URL}/spa/`,
-    storageState: 'e2e/storageState.json',
   },
   projects: [
     {
@@ -25,6 +24,7 @@ const config: PlaywrightTestConfig = {
       use: {
         ...devices['Desktop Chromium'],
         viewport: { width: 1920, height: 1080 },
+        storageState: undefined
       },
       
     },


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/OZ-831

This PR adds e2e tests for the OpenMRS and Orthanc flows covering the following test case: 
- Uploading a DICOM study in Orthanc creates the corresponding radiology image for the OpenMRS patient.