### PR TITLE
OZ-871: Add GitHub workflow to publish e2e tests to npm registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,8 @@
 name: Publish to NPM Registry
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - '1.0.0-*'
+  release:
+    types: [published]
 
 jobs:
   publish:


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/OZ-871

This PR adds a GA workflow for publishing e2e tests to npm registry. 