### PR TITLE
fix(ci): correctly set test status in Slack message by using shell exit code.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,7 +85,7 @@ jobs:
           echo "jobStatusPretty=$jobStatusPretty" >> "$GITHUB_ENV"
 
       - name: Notify Slack
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' }}
         id: slack
         uses: slackapi/slack-github-action@v1.24.0
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,9 +76,8 @@ jobs:
           OZONE_PASSWORD: '${{ secrets.OZONE_PASSWORD }}'
         run: |
           npm run ozone-e2e
-
-        if: ${{ github.event_name != 'pull_request' }}
-          if [[ ${{ job.status }} == "success" ]]; then
+          exit_code=$?
+          if [[ $exit_code -eq 0 ]]; then
             jobStatusPretty="✅ Passing"
           else
             jobStatusPretty="❌ Failing"
@@ -86,7 +85,7 @@ jobs:
           echo "jobStatusPretty=$jobStatusPretty" >> "$GITHUB_ENV"
 
       - name: Notify Slack
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' }}
         id: slack
         uses: slackapi/slack-github-action@v1.24.0
         with:

--- a/package.json
+++ b/package.json
@@ -14,14 +14,13 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "ozone-e2e": "npx playwright test keycloak-senaite",
+    "ozone-e2e": "npx playwright test",
     "openmrs-distro-his": "npx playwright test odoo-openmrs openmrs-senaite"
   },
   "publishConfig": {
     "registry": "https://nexus.mekomsolutions.net/repository/npm-public/"
   },
   "keywords": [],
-  "author": "",
   "devDependencies": {
     "@playwright/test": "^1.51.1",
     "@types/node": "^22.10.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "ozone-e2e": "npx playwright test",
+    "ozone-e2e": "npx playwright test keycloak-senaite",
     "openmrs-distro-his": "npx playwright test odoo-openmrs openmrs-senaite"
   },
   "publishConfig": {


### PR DESCRIPTION
This PR updates the script to use Bash's `$?` to capture the Playwright test command's exit code
and correctly sets the `jobStatusPretty` environment variable for the Slack message.

Previously, the job status was being checked using `${{ job.status }}` inside the `run` block,
which does not evaluate in shell context. This caused the `jobStatusPretty` variable to always
be empty in the Slack notification.