### PR TITLE
fix(ci): send Slack notifications only for builds on main

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,7 +85,7 @@ jobs:
           echo "jobStatusPretty=$jobStatusPretty" >> "$GITHUB_ENV"
 
       - name: Notify Slack
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
         id: slack
         uses: slackapi/slack-github-action@v1.24.0
         with:


### PR DESCRIPTION
This PR updates the GitHub Actions to send Slack notifications for only builds done on the main.

Convo: https://mekomsolutions.slack.com/archives/GSVHTJKM2/p1752676916865079